### PR TITLE
feat: Add exclude_patterns for filtering files from scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Constants strategy** for detecting unused constant definitions (`SCREAMING_SNAKE_CASE = value`)
 - **Delegations strategy** for detecting unused `delegate :method, to: :target` declarations
 - **Attributes strategy** for detecting unused `attr_accessor`, `attr_reader`, `attr_writer` declarations
-- **Config file support** (`keela.yml` or `.keela.yml`) for project-specific settings ([#6](https://github.com/kerrizor/keela/issues/6))
+- **Config file support** (`keela.yml` or `.keela.yml`) for project-specific settings
+- **Exclude patterns** via `--exclude` CLI flag or `exclude_patterns` in config file
 
 ### Fixed
 

--- a/exe/keela
+++ b/exe/keela
@@ -50,6 +50,10 @@ OptionParser.new do |opts|
     Keela.configuration.extensions = exts.split(",").map(&:strip)
   end
 
+  opts.on("--exclude PATTERN", "Glob pattern for files to exclude (can be used multiple times)") do |pattern|
+    Keela.configuration.exclude_patterns << pattern
+  end
+
   opts.on("--config PATH", "-c", "Path to config file (default: keela.yml or .keela.yml)") do |path|
     options[:config_path] = path
   end

--- a/lib/keela/config_file.rb
+++ b/lib/keela/config_file.rb
@@ -12,6 +12,7 @@ module Keela
   # Supported keys:
   #   - extensions: Array of file extensions to scan
   #   - directory_patterns: Array of glob patterns for directories to scan
+  #   - exclude_patterns: Array of glob patterns for files to exclude
   #   - excluded_path: Path to YAML file of excluded items
   #   - baseline_path: Path to baseline YAML file
   #   - required_directory: Directory that must exist for scanning to proceed
@@ -34,6 +35,7 @@ module Keela
     ALLOWED_KEYS = %w[
       extensions
       directory_patterns
+      exclude_patterns
       excluded_path
       baseline_path
       required_directory

--- a/lib/keela/configuration.rb
+++ b/lib/keela/configuration.rb
@@ -20,6 +20,9 @@ module Keela
     # Whether to show progress during scanning
     attr_accessor :show_progress
 
+    # Glob patterns for files to exclude from scanning
+    attr_accessor :exclude_patterns
+
     def initialize
       @extensions = %w[rb haml erb].freeze
       @directory_patterns = %w[
@@ -31,6 +34,7 @@ module Keela
       @baseline_path = nil
       @required_directory = nil
       @show_progress = true
+      @exclude_patterns = []
     end
   end
 end

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -73,7 +73,17 @@ module Keela
 
     def load_source_files
       Dir.glob(file_globs).each do |filename|
+        next if excluded_file?(filename)
+
         @source_files[filename] = File.readlines(filename)
+      end
+    end
+
+    def excluded_file?(filename)
+      return false if configuration.exclude_patterns.empty?
+
+      configuration.exclude_patterns.any? do |pattern|
+        File.fnmatch?(pattern, filename, File::FNM_PATHNAME | File::FNM_EXTGLOB)
       end
     end
 

--- a/test/keela/config_file_test.rb
+++ b/test/keela/config_file_test.rb
@@ -169,6 +169,19 @@ class ConfigFileTest < Minitest::Test
     assert_equal original_patterns, Keela.configuration.directory_patterns
   end
 
+  def test_loads_exclude_patterns
+    write_config(<<~YAML)
+      exclude_patterns:
+        - "vendor/**/*"
+        - "tmp/**/*"
+        - "node_modules/**/*"
+    YAML
+
+    Keela::ConfigFile.load
+
+    assert_equal %w[vendor/**/* tmp/**/* node_modules/**/*], Keela.configuration.exclude_patterns
+  end
+
   private
 
   def write_config(content, filename: "keela.yml")

--- a/test/keela/configuration_test.rb
+++ b/test/keela/configuration_test.rb
@@ -65,4 +65,13 @@ class ConfigurationTest < Minitest::Test
     @config.show_progress = false
     refute @config.show_progress
   end
+
+  def test_default_exclude_patterns_is_empty
+    assert_equal [], @config.exclude_patterns
+  end
+
+  def test_exclude_patterns_is_configurable
+    @config.exclude_patterns = %w[vendor/**/* tmp/**/*]
+    assert_equal %w[vendor/**/* tmp/**/*], @config.exclude_patterns
+  end
 end

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -131,4 +131,73 @@ class ScannerCommentHandlingTest < Minitest::Test
   end
 end
 
+class ScannerExcludePatternsTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    # Create test file structure
+    FileUtils.mkdir_p("app/models")
+    FileUtils.mkdir_p("vendor/gems")
+    FileUtils.mkdir_p("tmp/cache")
+
+    File.write("app/models/user.rb", "def user_method\nend\n")
+    File.write("vendor/gems/foo.rb", "def vendor_method\nend\n")
+    File.write("tmp/cache/bar.rb", "def tmp_method\nend\n")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_exclude_patterns_filters_out_matching_files
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[**/*.rb]
+    config.exclude_patterns = %w[vendor/**/* tmp/**/*]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    # Access file_globs and then load files
+    scanner.send(:load_source_files)
+
+    # Should only have app/models/user.rb, not vendor or tmp files
+    assert_includes scanner.source_files.keys, "app/models/user.rb"
+    refute scanner.source_files.keys.any? { |f| f.start_with?("vendor/") }
+    refute scanner.source_files.keys.any? { |f| f.start_with?("tmp/") }
+  end
+
+  def test_exclude_patterns_with_no_exclusions_includes_all_files
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[**/*.rb]
+    config.exclude_patterns = []
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.send(:load_source_files)
+
+    assert_includes scanner.source_files.keys, "app/models/user.rb"
+    assert_includes scanner.source_files.keys, "vendor/gems/foo.rb"
+    assert_includes scanner.source_files.keys, "tmp/cache/bar.rb"
+  end
+
+  def test_exclude_patterns_with_specific_file_pattern
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[**/*.rb]
+    config.exclude_patterns = %w[**/foo.rb]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.send(:load_source_files)
+
+    assert_includes scanner.source_files.keys, "app/models/user.rb"
+    refute_includes scanner.source_files.keys, "vendor/gems/foo.rb"
+    assert_includes scanner.source_files.keys, "tmp/cache/bar.rb"
+  end
+end
+
 


### PR DESCRIPTION
## Summary

Add ability to exclude files from scanning via glob patterns.

## Changes

- New `exclude_patterns` configuration option (array of globs)
- New `--exclude PATTERN` CLI flag (can be used multiple times)
- Config file support via `exclude_patterns` key in keela.yml

## Usage

### CLI
```bash
keela --exclude 'vendor/**/*' --exclude 'tmp/**/*'
```

### Config file (keela.yml)
```yaml
exclude_patterns:
  - vendor/**/*
  - tmp/**/*
  - node_modules/**/*
```

## Implementation

Patterns use Ruby's `File.fnmatch?` with `FNM_PATHNAME` and `FNM_EXTGLOB` flags for flexible matching.

Closes #6