### PR TITLE
feat: Add --include flag for additional directories to scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Attributes strategy** for detecting unused `attr_accessor`, `attr_reader`, `attr_writer` declarations
 - **Config file support** (`keela.yml` or `.keela.yml`) for project-specific settings
 - **Exclude patterns** via `--exclude` CLI flag or `exclude_patterns` in config file
+- **Include patterns** via `--include` CLI flag or `include_patterns` in config file (adds to default directory patterns)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ keela --extensions rb,rake,haml
 # Exclude files matching patterns
 keela --exclude 'vendor/**/*' --exclude 'tmp/**/*'
 
+# Include additional directories (adds to defaults)
+keela --include 'engines/**/*.rb' --include 'custom/**/*.rb'
+
 # Use a custom config file
 keela --config path/to/keela.yml
 
@@ -124,11 +127,6 @@ Create a `keela.yml` or `.keela.yml` in your project root:
 
 ```yaml
 # keela.yml
-directory_patterns:
-  - "app/**/*.%<ext>s"
-  - "lib/**/*.%<ext>s"
-  - "config/**/*.%<ext>s"
-
 extensions:
   - rb
   - haml
@@ -137,7 +135,9 @@ extensions:
 exclude_patterns:
   - "vendor/**/*"
   - "tmp/**/*"
-  - "node_modules/**/*"
+
+include_patterns:
+  - "engines/**/*.%<ext>s"
 
 excluded_path: ".keela_excluded.yml"
 baseline_path: ".keela_baseline.yml"
@@ -145,13 +145,39 @@ baseline_path: ".keela_baseline.yml"
 
 Keela automatically loads `keela.yml` or `.keela.yml` from the current directory. Use `--config` to specify a different path.
 
+### Customizing Which Files to Scan
+
+There are two approaches:
+
+**1. Tweak the defaults** with `--include` and `--exclude` (or `include_patterns`/`exclude_patterns` in config):
+
+```bash
+# Add engines/ to the default app/, lib/, config/ directories
+keela --include 'engines/**/*.rb'
+
+# Exclude vendor files from scanning
+keela --exclude 'vendor/**/*'
+```
+
+**2. Full control** with `directory_patterns` - replaces the defaults entirely:
+
+```yaml
+# keela.yml - scan ONLY these directories
+directory_patterns:
+  - "src/**/*.%<ext>s"
+  - "custom/**/*.%<ext>s"
+```
+
+Use `directory_patterns` when you need complete control. Use `--include`/`--exclude` when you just want to tweak the defaults. You typically wouldn't mix both approaches.
+
 **Available options:**
 
 | Key | Description | Default |
 |-----|-------------|---------|
-| `directory_patterns` | Glob patterns for files to scan (use `%<ext>s` as extension placeholder) | `app/`, `lib/`, `config/` |
+| `directory_patterns` | Glob patterns for files to scan (replaces defaults) | `app/`, `lib/`, `config/` |
 | `extensions` | File extensions to scan | `rb`, `haml`, `erb` |
-| `exclude_patterns` | Glob patterns for files to exclude | `[]` |
+| `include_patterns` | Additional patterns to scan (added to defaults) | `[]` |
+| `exclude_patterns` | Patterns for files to exclude | `[]` |
 | `excluded_path` | Path to YAML file of excluded items | `nil` |
 | `baseline_path` | Path to baseline YAML file | `.keela_baseline.yml` |
 | `required_directory` | Directory that must exist for scanning to proceed | `nil` |
@@ -212,6 +238,7 @@ Keela.configure do |config|
     app/**/*.%<ext>s
     lib/**/*.%<ext>s
   ]
+  config.include_patterns = %w[engines/**/*.%<ext>s]
   config.exclude_patterns = %w[vendor/**/* tmp/**/*]
   config.excluded_path = '.keela_excluded.yml'
   config.baseline_path = '.keela_baseline.yml'

--- a/exe/keela
+++ b/exe/keela
@@ -54,6 +54,10 @@ OptionParser.new do |opts|
     Keela.configuration.exclude_patterns << pattern
   end
 
+  opts.on("--include PATTERN", "Additional glob pattern to scan (can be used multiple times)") do |pattern|
+    Keela.configuration.include_patterns << pattern
+  end
+
   opts.on("--config PATH", "-c", "Path to config file (default: keela.yml or .keela.yml)") do |path|
     options[:config_path] = path
   end

--- a/lib/keela/config_file.rb
+++ b/lib/keela/config_file.rb
@@ -35,6 +35,7 @@ module Keela
     ALLOWED_KEYS = %w[
       extensions
       directory_patterns
+      include_patterns
       exclude_patterns
       excluded_path
       baseline_path

--- a/lib/keela/configuration.rb
+++ b/lib/keela/configuration.rb
@@ -23,6 +23,9 @@ module Keela
     # Glob patterns for files to exclude from scanning
     attr_accessor :exclude_patterns
 
+    # Additional directory patterns to include (added to directory_patterns)
+    attr_accessor :include_patterns
+
     def initialize
       @extensions = %w[rb haml erb].freeze
       @directory_patterns = %w[
@@ -35,6 +38,7 @@ module Keela
       @required_directory = nil
       @show_progress = true
       @exclude_patterns = []
+      @include_patterns = []
     end
   end
 end

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -54,8 +54,10 @@ module Keela
     end
 
     def file_globs
+      all_patterns = configuration.directory_patterns + configuration.include_patterns
+
       configuration.extensions.flat_map do |ext|
-        configuration.directory_patterns.map { |pattern| format(pattern, ext: ext) }
+        all_patterns.map { |pattern| format(pattern, ext: ext) }
       end
     end
 

--- a/test/keela/config_file_test.rb
+++ b/test/keela/config_file_test.rb
@@ -182,6 +182,18 @@ class ConfigFileTest < Minitest::Test
     assert_equal %w[vendor/**/* tmp/**/* node_modules/**/*], Keela.configuration.exclude_patterns
   end
 
+  def test_loads_include_patterns
+    write_config(<<~YAML)
+      include_patterns:
+        - "engines/**/*.%<ext>s"
+        - "custom/**/*.%<ext>s"
+    YAML
+
+    Keela::ConfigFile.load
+
+    assert_equal %w[engines/**/*.%<ext>s custom/**/*.%<ext>s], Keela.configuration.include_patterns
+  end
+
   private
 
   def write_config(content, filename: "keela.yml")

--- a/test/keela/configuration_test.rb
+++ b/test/keela/configuration_test.rb
@@ -74,4 +74,13 @@ class ConfigurationTest < Minitest::Test
     @config.exclude_patterns = %w[vendor/**/* tmp/**/*]
     assert_equal %w[vendor/**/* tmp/**/*], @config.exclude_patterns
   end
+
+  def test_default_include_patterns_is_empty
+    assert_equal [], @config.include_patterns
+  end
+
+  def test_include_patterns_is_configurable
+    @config.include_patterns = %w[engines/**/*.%<ext>s custom/**/*.%<ext>s]
+    assert_equal %w[engines/**/*.%<ext>s custom/**/*.%<ext>s], @config.include_patterns
+  end
 end

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -200,4 +200,91 @@ class ScannerExcludePatternsTest < Minitest::Test
   end
 end
 
+class ScannerIncludePatternsTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    # Create test file structure
+    FileUtils.mkdir_p("app/models")
+    FileUtils.mkdir_p("lib")
+    FileUtils.mkdir_p("engines/billing/app/models")
+    FileUtils.mkdir_p("custom/services")
+
+    File.write("app/models/user.rb", "def user_method\nend\n")
+    File.write("lib/utils.rb", "def lib_method\nend\n")
+    File.write("engines/billing/app/models/invoice.rb", "def invoice_method\nend\n")
+    File.write("custom/services/payment.rb", "def payment_method\nend\n")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_include_patterns_adds_to_directory_patterns
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[app/**/*.rb lib/**/*.rb]
+    config.include_patterns = %w[engines/**/*.rb]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.send(:load_source_files)
+
+    # Should have files from both directory_patterns AND include_patterns
+    assert_includes scanner.source_files.keys, "app/models/user.rb"
+    assert_includes scanner.source_files.keys, "lib/utils.rb"
+    assert_includes scanner.source_files.keys, "engines/billing/app/models/invoice.rb"
+    refute scanner.source_files.keys.any? { |f| f.start_with?("custom/") }
+  end
+
+  def test_include_patterns_with_multiple_patterns
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[app/**/*.rb]
+    config.include_patterns = %w[engines/**/*.rb custom/**/*.rb]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.send(:load_source_files)
+
+    assert_includes scanner.source_files.keys, "app/models/user.rb"
+    assert_includes scanner.source_files.keys, "engines/billing/app/models/invoice.rb"
+    assert_includes scanner.source_files.keys, "custom/services/payment.rb"
+    refute scanner.source_files.keys.any? { |f| f.start_with?("lib/") }
+  end
+
+  def test_include_patterns_empty_does_not_change_behavior
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[app/**/*.rb]
+    config.include_patterns = []
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.send(:load_source_files)
+
+    assert_includes scanner.source_files.keys, "app/models/user.rb"
+    refute scanner.source_files.keys.any? { |f| f.start_with?("engines/") }
+    refute scanner.source_files.keys.any? { |f| f.start_with?("custom/") }
+  end
+
+  def test_file_globs_includes_both_directory_and_include_patterns
+    config = Keela::Configuration.new
+    config.extensions = %w[rb]
+    config.directory_patterns = %w[app/**/*.%<ext>s]
+    config.include_patterns = %w[engines/**/*.%<ext>s]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    globs = scanner.file_globs
+
+    assert_includes globs, "app/**/*.rb"
+    assert_includes globs, "engines/**/*.rb"
+  end
+end
+
 


### PR DESCRIPTION
## Summary

Add `--include` CLI flag and `include_patterns` config option to scan additional directories without replacing the defaults.

## Usage

### CLI
```bash
# Add engines/ to the default app/, lib/, config/ directories
keela --include 'engines/**/*.rb' --include 'custom/**/*.rb'
```

### Config file
```yaml
include_patterns:
  - "engines/**/*.%<ext>s"
  - "custom/**/*.%<ext>s"
```

## Two Approaches to Customization

1. **Tweak defaults** - Use `--include`/`--exclude` (or config equivalents) to add/remove from the default `app/`, `lib/`, `config/` directories

2. **Full control** - Use `directory_patterns` in config to replace defaults entirely

You typically wouldn't mix both approaches - if you're setting `directory_patterns`, you've already defined exactly what you want.

## Changes

- New `include_patterns` configuration option
- New `--include PATTERN` CLI flag (can be used multiple times)  
- Config file support via `include_patterns` key
- Updated README with clearer documentation on customization approaches

Completes #6