### PR TITLE
feat: Validate configuration to prevent conflicting pattern options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Config file support** (`keela.yml` or `.keela.yml`) for project-specific settings
 - **Exclude patterns** via `--exclude` CLI flag or `exclude_patterns` in config file
 - **Include patterns** via `--include` CLI flag or `include_patterns` in config file (adds to default directory patterns)
+- **Configuration validation** - raises `ConfigurationError` if `directory_patterns` is customized while also using `include_patterns` or `exclude_patterns`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ directory_patterns:
   - "custom/**/*.%<ext>s"
 ```
 
-Use `directory_patterns` when you need complete control. Use `--include`/`--exclude` when you just want to tweak the defaults. You typically wouldn't mix both approaches.
+Use `directory_patterns` when you need complete control. Use `--include`/`--exclude` when you just want to tweak the defaults.
+
+**Note:** Mixing both approaches raises a `ConfigurationError`. Choose one or the other.
 
 **Available options:**
 

--- a/lib/keela.rb
+++ b/lib/keela.rb
@@ -14,6 +14,9 @@ require_relative "keela/baseline"
 require_relative "keela/scanner"
 
 module Keela
+  class Error < StandardError; end
+  class ConfigurationError < Error; end
+
   class << self
     attr_writer :configuration
 

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -20,6 +20,8 @@ module Keela
     def run(force_report: false, update_baseline: false)
       return true unless should_run?
 
+      validate_configuration!
+
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       load_source_files
@@ -67,6 +69,22 @@ module Keela
       return true unless configuration.required_directory
 
       Dir.exist?(configuration.required_directory)
+    end
+
+    def validate_configuration!
+      custom_directory_patterns = configuration.directory_patterns != default_directory_patterns
+      has_include_patterns = !configuration.include_patterns.empty?
+      has_exclude_patterns = !configuration.exclude_patterns.empty?
+
+      return unless custom_directory_patterns && (has_include_patterns || has_exclude_patterns)
+
+      raise ConfigurationError,
+        "Cannot use include_patterns or exclude_patterns with custom directory_patterns. " \
+        "Use directory_patterns for full control, OR use include/exclude to tweak the defaults."
+    end
+
+    def default_directory_patterns
+      Keela::Configuration.new.directory_patterns
     end
 
     def reporter

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -274,7 +274,7 @@ class ScannerIncludePatternsTest < Minitest::Test
   def test_file_globs_includes_both_directory_and_include_patterns
     config = Keela::Configuration.new
     config.extensions = %w[rb]
-    config.directory_patterns = %w[app/**/*.%<ext>s]
+    # Using default directory_patterns, adding include_patterns
     config.include_patterns = %w[engines/**/*.%<ext>s]
 
     strategy = Keela::Strategies::Methods.new
@@ -284,6 +284,81 @@ class ScannerIncludePatternsTest < Minitest::Test
 
     assert_includes globs, "app/**/*.rb"
     assert_includes globs, "engines/**/*.rb"
+  end
+end
+
+class ScannerConfigurationValidationTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    FileUtils.mkdir_p("app/models")
+    File.write("app/models/user.rb", "def user_method\nend\n")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_raises_error_when_custom_directory_patterns_with_include_patterns
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[src/**/*.rb]  # Custom, not default
+    config.include_patterns = %w[engines/**/*.rb]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    error = assert_raises(Keela::ConfigurationError) { scanner.run }
+    assert_match(/Cannot use include_patterns or exclude_patterns with custom directory_patterns/, error.message)
+  end
+
+  def test_raises_error_when_custom_directory_patterns_with_exclude_patterns
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[src/**/*.rb]  # Custom, not default
+    config.exclude_patterns = %w[vendor/**/*]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    error = assert_raises(Keela::ConfigurationError) { scanner.run }
+    assert_match(/Cannot use include_patterns or exclude_patterns with custom directory_patterns/, error.message)
+  end
+
+  def test_allows_default_directory_patterns_with_include_patterns
+    config = Keela::Configuration.new
+    # Using default directory_patterns
+    config.include_patterns = %w[engines/**/*.rb]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    # Should not raise - this is the valid use case
+    assert scanner.run
+  end
+
+  def test_allows_default_directory_patterns_with_exclude_patterns
+    config = Keela::Configuration.new
+    # Using default directory_patterns
+    config.exclude_patterns = %w[vendor/**/*]
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    # Should not raise - this is the valid use case
+    assert scanner.run
+  end
+
+  def test_allows_custom_directory_patterns_without_include_or_exclude
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[app/**/*.rb]  # Custom, but no include/exclude
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    # Should not raise - full control mode without tweaks
+    assert scanner.run
   end
 end
 


### PR DESCRIPTION
## Summary

Raise `ConfigurationError` if `directory_patterns` is customized while also using `include_patterns` or `exclude_patterns`.

## Why

These are two different approaches to customization:

1. **Full control**: Set `directory_patterns` to exactly what you want to scan
2. **Tweak defaults**: Use `--include`/`--exclude` to modify the default `app/`, `lib/`, `config/` directories

Mixing both is confusing and likely a misconfiguration. For example:

```yaml
# This is confusing - are we scanning src/ or src/ + engines/?
directory_patterns:
  - "src/**/*.rb"
include_patterns:
  - "engines/**/*.rb"
```

## Behavior

| Configuration | Result |
|--------------|--------|
| Default `directory_patterns` + `include_patterns` | ✅ Valid |
| Default `directory_patterns` + `exclude_patterns` | ✅ Valid |
| Custom `directory_patterns` alone | ✅ Valid |
| Custom `directory_patterns` + `include_patterns` | ❌ `ConfigurationError` |
| Custom `directory_patterns` + `exclude_patterns` | ❌ `ConfigurationError` |

## Error Message

```
Cannot use include_patterns or exclude_patterns with custom directory_patterns.
Use directory_patterns for full control, OR use include/exclude to tweak the defaults.
```