### PR TITLE
Add JSON output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configuration validation** - raises `ConfigurationError` if `directory_patterns` is customized while also using `include_patterns` or `exclude_patterns`
 - **I18n keys strategy (beta)** for detecting unused translation keys in locale files (`--type i18n_keys`)
 - **Multiple types** can now be specified with `--type methods,scopes,constants`
+- **JSON output** via `--format json` for machine-readable results (useful for CI integrations)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ keela --format json --report
 
 ```json
 {
-  "version": "0.2.0",
   "strategies": ["methods", "scopes"],
   "unused": {
     "methods": {

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ keela --include 'engines/**/*.rb' --include 'custom/**/*.rb'
 # Use a custom config file
 keela --config path/to/keela.yml
 
+# Output as JSON (for CI integrations)
+keela --format json
+
 # Show version
 keela --version
 ```
@@ -222,6 +225,38 @@ The workflow:
 1. **Initial setup**: Run `keela --update-baseline` and commit `.keela_baseline.yml`
 2. **CI runs**: `keela` compares against baseline, fails on new dead code
 3. **After cleanup**: Run `keela --update-baseline` to update the baseline
+
+### JSON Output
+
+Use `--format json` for machine-readable output:
+
+```bash
+keela --format json --report
+```
+
+```json
+{
+  "version": "0.2.0",
+  "strategies": ["methods", "scopes"],
+  "unused": {
+    "methods": {
+      "app/models/user.rb": ["unused_method", "old_helper"]
+    },
+    "scopes": {
+      "app/models/post.rb": ["inactive"]
+    }
+  },
+  "summary": {
+    "total": 3,
+    "by_strategy": {
+      "methods": 2,
+      "scopes": 1
+    }
+  }
+}
+```
+
+This is useful for integrating with other tools, generating reports, or processing results programmatically.
 
 ## Exclusion File
 

--- a/exe/keela
+++ b/exe/keela
@@ -160,7 +160,6 @@ if json_mode
   by_strategy = results.transform_values { |files| files.values.flatten.size }
 
   output = {
-    version: Keela::VERSION,
     strategies: strategies.map(&:name),
     unused: results.reject { |_, v| v.empty? },
     summary: {

--- a/exe/keela
+++ b/exe/keela
@@ -8,7 +8,8 @@ options = {
   type: :all,
   force_report: false,
   update_baseline: false,
-  config_path: nil
+  config_path: nil,
+  format: :text
 }
 
 OptionParser.new do |opts|
@@ -36,6 +37,10 @@ OptionParser.new do |opts|
 
   opts.on("--update-baseline", "-u", "Update the baseline file with current unused code") do
     options[:update_baseline] = true
+  end
+
+  opts.on("--format FORMAT", %i[text json], "Output format: text (default) or json") do |format|
+    options[:format] = format
   end
 
   opts.on("--excluded PATH", "Path to YAML file of excluded items") do |path|
@@ -117,20 +122,54 @@ strategies = build_strategies(options[:types])
 baseline = Keela::Baseline.new(Keela.configuration.baseline_path)
 
 success = true
+results = {}
+
+json_mode = options[:format] == :json
 
 strategies.each_with_index do |strategy, index|
-  puts Rainbow("=== Sniffing for unused #{strategy.name} ===").cyan.bright if strategies.size > 1
+  unless json_mode
+    puts Rainbow("=== Sniffing for unused #{strategy.name} ===").cyan.bright if strategies.size > 1
+  end
 
   scanner = Keela::Scanner.new(strategy: strategy, baseline: baseline)
-  success &&= scanner.run(force_report: options[:force_report], update_baseline: options[:update_baseline])
+  success &&= scanner.run(
+    force_report: options[:force_report],
+    update_baseline: options[:update_baseline],
+    silent: json_mode
+  )
 
-  puts if strategies.size > 1 && index < strategies.size - 1
+  # Collect results for JSON output
+  results[strategy.name] = scanner.unused_collection.transform_values(&:to_a)
+
+  unless json_mode
+    puts if strategies.size > 1 && index < strategies.size - 1
+  end
 end
 
 # Save baseline after all strategies have run
 if options[:update_baseline]
   baseline.save
-  puts Rainbow("Updated #{baseline.path}").green.bright
+  puts Rainbow("Updated #{baseline.path}").green.bright unless json_mode
+end
+
+# Output JSON if requested
+if json_mode
+  require "json"
+
+  total = results.values.flat_map(&:values).flatten.size
+  by_strategy = results.transform_values { |files| files.values.flatten.size }
+
+  output = {
+    version: Keela::VERSION,
+    strategies: strategies.map(&:name),
+    unused: results.reject { |_, v| v.empty? },
+    summary: {
+      total: total,
+      by_strategy: by_strategy.reject { |_, v| v.zero? }
+    }
+  }
+
+  puts JSON.pretty_generate(output)
 end
 
 exit(success ? 0 : 1)

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -17,7 +17,7 @@ module Keela
       @removed = []
     end
 
-    def run(force_report: false, update_baseline: false)
+    def run(force_report: false, update_baseline: false, silent: false)
       return true unless should_run?
 
       validate_configuration!
@@ -31,11 +31,11 @@ module Keela
       # Determine mode: report if forced, updating baseline, or no baseline exists
       report_mode = force_report || update_baseline || !baseline.exists?
 
-      find_unused(definitions, show_progress: report_mode)
+      find_unused(definitions, show_progress: report_mode && !silent)
 
       if report_mode
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-        reporter.print_full_report(unused_collection, elapsed)
+        reporter.print_full_report(unused_collection, elapsed) unless silent
         if update_baseline
           baseline.set(strategy.name, unused_collection)
           # Note: caller is responsible for calling baseline.save after all strategies run
@@ -45,12 +45,14 @@ module Keela
 
       # Baseline mode: compare against known unused code
       compare_with_baseline
-      reporter.print_diff_report(
-        new_unused,
-        removed,
-        excluded_path: configuration.excluded_path || "excluded.yml",
-        baseline_path: baseline.path
-      )
+      unless silent
+        reporter.print_diff_report(
+          new_unused,
+          removed,
+          excluded_path: configuration.excluded_path || "excluded.yml",
+          baseline_path: baseline.path
+        )
+      end
 
       new_unused.empty? && removed.empty?
     end

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -287,6 +287,57 @@ class ScannerIncludePatternsTest < Minitest::Test
   end
 end
 
+class ScannerSilentModeTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    FileUtils.mkdir_p("app/models")
+    File.write("app/models/user.rb", "def unused_method\nend\n")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_silent_mode_suppresses_output
+    config = Keela::Configuration.new
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    output = capture_io do
+      scanner.run(force_report: true, silent: true)
+    end
+
+    assert_empty output[0], "Expected no stdout output in silent mode"
+  end
+
+  def test_silent_mode_still_populates_unused_collection
+    config = Keela::Configuration.new
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.run(force_report: true, silent: true)
+
+    refute_empty scanner.unused_collection
+    assert_includes scanner.unused_collection["app/models/user.rb"], "unused_method"
+  end
+
+  def test_non_silent_mode_produces_output
+    config = Keela::Configuration.new
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    output = capture_io do
+      scanner.run(force_report: true, silent: false)
+    end
+
+    refute_empty output[0], "Expected stdout output in non-silent mode"
+  end
+end
+
 class ScannerConfigurationValidationTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir


### PR DESCRIPTION
Add `--format json` flag for machine-readable output, useful for CI integrations and programmatic processing.

## Changes

- Add `--format json` CLI flag
- Add `silent` option to `Scanner#run` to suppress text output
- JSON output includes version, strategies, unused items, and summary

## Example

```bash
keela --format json --report
```

```json
{
  "version": "0.2.0",
  "strategies": ["methods", "scopes"],
  "unused": {
    "methods": {
      "app/models/user.rb": ["unused_method"]
    }
  },
  "summary": {
    "total": 1,
    "by_strategy": {
      "methods": 1
    }
  }
}
```

## Testing

- Added tests for silent mode in `ScannerSilentModeTest`
- Manual testing with real codebases