### PR TITLE
Add --quiet / -q flag to suppress progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Quiet mode** via `--quiet` / `-q` CLI flag to suppress progress bar output ([#26](https://github.com/kerrizor/keela/issues/26))
+
 ## [0.2.0] - 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ keela --config path/to/keela.yml
 # Output as JSON (for CI integrations)
 keela --format json
 
+# Suppress progress bar (useful for CI and scripting)
+keela --quiet
+keela -q
+
 # Show version
 keela --version
 ```

--- a/exe/keela
+++ b/exe/keela
@@ -9,7 +9,8 @@ options = {
   force_report: false,
   update_baseline: false,
   config_path: nil,
-  format: :text
+  format: :text,
+  quiet: false
 }
 
 OptionParser.new do |opts|
@@ -72,6 +73,10 @@ OptionParser.new do |opts|
     exit
   end
 
+  opts.on("--quiet", "-q", "Suppress progress bar output (useful for CI and scripting)") do
+    options[:quiet] = true
+  end
+
   opts.on("-h", "--help", "Show this help") do
     puts opts
     exit
@@ -81,6 +86,9 @@ end.parse!
 # Load config file (keela.yml or .keela.yml) if present
 # CLI options override config file settings
 Keela::ConfigFile.load(path: options[:config_path])
+
+# Apply quiet mode if requested
+Keela.configuration.show_progress = false if options[:quiet]
 
 # Set default baseline path if not specified
 Keela.configuration.baseline_path ||= ".keela_baseline.yml"

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -31,7 +31,7 @@ module Keela
       # Determine mode: report if forced, updating baseline, or no baseline exists
       report_mode = force_report || update_baseline || !baseline.exists?
 
-      find_unused(definitions, show_progress: report_mode && !silent)
+      find_unused(definitions, show_progress: report_mode && !silent && configuration.show_progress)
 
       if report_mode
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -338,6 +338,49 @@ class ScannerSilentModeTest < Minitest::Test
   end
 end
 
+class ScannerShowProgressTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    FileUtils.mkdir_p("app/models")
+    File.write("app/models/user.rb", "def unused_method\nend\n")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_show_progress_false_suppresses_progress_bar
+    config = Keela::Configuration.new
+    config.show_progress = false
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    # In report mode, progress would normally show, but show_progress=false should suppress it
+    output = capture_io do
+      scanner.run(force_report: true, silent: false)
+    end
+
+    # The output should contain the report but NOT progress bar output
+    # Progress bar output contains "Checking methods" with ANSI codes
+    refute_match(/Checking methods.*\r/, output[0], "Progress bar should be suppressed when show_progress is false")
+  end
+
+  def test_show_progress_true_allows_progress_bar_in_report_mode
+    config = Keela::Configuration.new
+    config.show_progress = true
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    # This test just ensures the scanner runs without error when show_progress is true
+    # Actually testing progress bar output is tricky due to TTY detection
+    assert scanner.run(force_report: true, silent: false)
+  end
+end
+
 class ScannerConfigurationValidationTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir


### PR DESCRIPTION
## Summary

Add a CLI flag to disable the progress bar output, which can interfere with CI tools and AI agents that parse stdout.

## Changes

- Add `--quiet` / `-q` CLI flag to `exe/keela`
- Wire the flag to `Keela.configuration.show_progress`
- Update `Scanner#run` to respect `configuration.show_progress`
- Add tests for the new functionality
- Update README and CHANGELOG

## Usage

```bash
# Suppress progress bar for CI/agent environments
keela --quiet
keela -q

# Combine with other options
keela -q --format json
```

Closes #26