### PR TITLE
Change default excluded filename to keela_excluded.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Quiet mode** via `--quiet` / `-q` CLI flag to suppress progress bar output ([#26](https://github.com/kerrizor/keela/issues/26))
 
+### Changed
+
+- Default suggested excluded filename changed from `excluded.yml` to `keela_excluded.yml` for consistency with `keela_baseline.yml` ([#28](https://github.com/kerrizor/keela/pull/28))
+
 ## [0.2.0] - 2026-07-17
 
 ### Added

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -49,7 +49,7 @@ module Keela
         reporter.print_diff_report(
           new_unused,
           removed,
-          excluded_path: configuration.excluded_path || "excluded.yml",
+          excluded_path: configuration.excluded_path || "keela_excluded.yml",
           baseline_path: baseline.path
         )
       end


### PR DESCRIPTION
Update the suggested filename for exclusions from `excluded.yml` to `keela_excluded.yml` for consistency with `keela_baseline.yml` naming convention.

This only affects the filename suggested to users in output messages when no `excluded_path` is configured. The configuration still defaults to `nil` (not required).