### PR TITLE
Support .keela/ directory for default file locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Default suggested excluded filename changed from `excluded.yml` to `keela_excluded.yml` for consistency with `keela_baseline.yml` ([#28](https://github.com/kerrizor/keela/pull/28))
+- Default file locations now support `.keela/` directory with fallback to root ([#29](https://github.com/kerrizor/keela/pull/29))
+  - Excluded: `.keela/excluded.yml` → `keela_excluded.yml`
+  - Baseline: `.keela/baseline.yml` → `keela_baseline.yml`
 
 ## [0.2.0] - 2026-07-17
 

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -7,10 +7,13 @@ module Keela
   class Scanner
     attr_reader :strategy, :configuration, :baseline, :source_files, :unused_collection, :new_unused, :removed
 
+    DEFAULT_EXCLUDED_PATHS = [".keela/excluded.yml", "keela_excluded.yml"].freeze
+    DEFAULT_BASELINE_PATHS = [".keela/baseline.yml", "keela_baseline.yml"].freeze
+
     def initialize(strategy:, configuration: Keela.configuration, baseline: nil)
       @strategy = strategy
       @configuration = configuration
-      @baseline = baseline || Baseline.new(configuration.baseline_path)
+      @baseline = baseline || Baseline.new(resolve_baseline_path)
       @source_files = {}
       @unused_collection = Hash.new { |hash, key| hash[key] = [] }
       @new_unused = []
@@ -49,7 +52,7 @@ module Keela
         reporter.print_diff_report(
           new_unused,
           removed,
-          excluded_path: configuration.excluded_path || "keela_excluded.yml",
+          excluded_path: resolve_excluded_path || ".keela/excluded.yml",
           baseline_path: baseline.path
         )
       end
@@ -128,15 +131,29 @@ module Keela
     end
 
     def filter_excluded(definitions)
-      return definitions unless configuration.excluded_path
-      return definitions unless File.exist?(configuration.excluded_path)
+      path = resolve_excluded_path
+      return definitions unless path
 
-      excluded = YAML.load_file(configuration.excluded_path, symbolize_names: true) || {}
+      excluded = YAML.load_file(path, symbolize_names: true) || {}
 
       definitions.reject do |h|
         excluded_for_file = excluded[h[:file].to_sym]
         excluded_for_file&.flat_map(&:keys)&.include?(h[:name].to_sym)
       end
+    end
+
+    def resolve_excluded_path
+      return configuration.excluded_path if configuration.excluded_path && File.exist?(configuration.excluded_path)
+
+      # Check default locations in order of preference
+      DEFAULT_EXCLUDED_PATHS.find { |path| File.exist?(path) }
+    end
+
+    def resolve_baseline_path
+      return configuration.baseline_path if configuration.baseline_path && File.exist?(configuration.baseline_path)
+
+      # Check default locations in order of preference
+      DEFAULT_BASELINE_PATHS.find { |path| File.exist?(path) }
     end
 
     def find_unused(definitions, show_progress: false)

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -454,6 +454,140 @@ class ScannerConfigurationValidationTest < Minitest::Test
     # Should not raise - full control mode without tweaks
     assert scanner.run
   end
+
+  # resolve_excluded_path tests
+
+  def test_resolve_excluded_path_returns_configured_path_when_file_exists
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.write("custom_excluded.yml", "---\n{}")
+
+        config = Keela::Configuration.new
+        config.excluded_path = "custom_excluded.yml"
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_equal "custom_excluded.yml", scanner.send(:resolve_excluded_path)
+      end
+    end
+  end
+
+  def test_resolve_excluded_path_returns_nil_when_configured_path_does_not_exist
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        config = Keela::Configuration.new
+        config.excluded_path = "nonexistent.yml"
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_nil scanner.send(:resolve_excluded_path)
+      end
+    end
+  end
+
+  def test_resolve_excluded_path_prefers_keela_directory
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        Dir.mkdir(".keela")
+        File.write(".keela/excluded.yml", "---\n{}")
+        File.write("keela_excluded.yml", "---\n{}")
+
+        config = Keela::Configuration.new
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_equal ".keela/excluded.yml", scanner.send(:resolve_excluded_path)
+      end
+    end
+  end
+
+  def test_resolve_excluded_path_falls_back_to_root_file
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.write("keela_excluded.yml", "---\n{}")
+
+        config = Keela::Configuration.new
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_equal "keela_excluded.yml", scanner.send(:resolve_excluded_path)
+      end
+    end
+  end
+
+  def test_resolve_excluded_path_returns_nil_when_no_files_exist
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        config = Keela::Configuration.new
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_nil scanner.send(:resolve_excluded_path)
+      end
+    end
+  end
+
+  # resolve_baseline_path tests
+
+  def test_resolve_baseline_path_returns_configured_path_when_file_exists
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.write("custom_baseline.yml", "---\n{}")
+
+        config = Keela::Configuration.new
+        config.baseline_path = "custom_baseline.yml"
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_equal "custom_baseline.yml", scanner.send(:resolve_baseline_path)
+      end
+    end
+  end
+
+  def test_resolve_baseline_path_returns_nil_when_configured_path_does_not_exist
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        config = Keela::Configuration.new
+        config.baseline_path = "nonexistent.yml"
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_nil scanner.send(:resolve_baseline_path)
+      end
+    end
+  end
+
+  def test_resolve_baseline_path_prefers_keela_directory
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        Dir.mkdir(".keela")
+        File.write(".keela/baseline.yml", "---\n{}")
+        File.write("keela_baseline.yml", "---\n{}")
+
+        config = Keela::Configuration.new
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_equal ".keela/baseline.yml", scanner.send(:resolve_baseline_path)
+      end
+    end
+  end
+
+  def test_resolve_baseline_path_falls_back_to_root_file
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        File.write("keela_baseline.yml", "---\n{}")
+
+        config = Keela::Configuration.new
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_equal "keela_baseline.yml", scanner.send(:resolve_baseline_path)
+      end
+    end
+  end
+
+  def test_resolve_baseline_path_returns_nil_when_no_files_exist
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        config = Keela::Configuration.new
+        scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+        assert_nil scanner.send(:resolve_baseline_path)
+      end
+    end
+  end
 end
 
 


### PR DESCRIPTION
Add support for organizing Keela files in a `.keela/` directory with fallback to root-level files for backwards compatibility.

**Lookup order:**
- Excluded: `.keela/excluded.yml` → `keela_excluded.yml`
- Baseline: `.keela/baseline.yml` → `keela_baseline.yml`

Explicit configuration via `excluded_path` or `baseline_path` still takes precedence over the default locations.

This keeps the project root cleaner and follows patterns like `.github/`, `.vscode/`, etc.