### PR TITLE
Support .keela/config.yml for configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Config file lookup now includes `.keela/config.yml` as the first option ([#30](https://github.com/kerrizor/keela/pull/30))
+  - Lookup order: `.keela/config.yml` → `keela.yml` → `.keela.yml`
+
 ## [0.2.1] - 2026-07-27
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keela (0.2.0)
+    keela (0.2.1)
       parallel (~> 1.20)
       rainbow (~> 3.0)
       ruby-progressbar (~> 1.11)
@@ -26,7 +26,7 @@ DEPENDENCIES
 
 CHECKSUMS
   bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
-  keela (0.2.0)
+  keela (0.2.1)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a

--- a/lib/keela/config_file.rb
+++ b/lib/keela/config_file.rb
@@ -3,11 +3,12 @@
 require "yaml"
 
 module Keela
-  # Loads configuration from a YAML file.
-  #
-  # Looks for config files in this order:
-  #   1. keela.yml
-  #   2. .keela.yml
+# Loads configuration from a YAML file.
+#
+# Looks for config files in this order:
+#   1. .keela/config.yml
+#   2. keela.yml
+#   3. .keela.yml
   #
   # Supported keys:
   #   - extensions: Array of file extensions to scan
@@ -30,7 +31,7 @@ module Keela
   #     - erb
   #
   module ConfigFile
-    CONFIG_FILENAMES = %w[keela.yml .keela.yml].freeze
+    CONFIG_FILENAMES = %w[.keela/config.yml keela.yml .keela.yml].freeze
 
     ALLOWED_KEYS = %w[
       extensions

--- a/test/keela/config_file_test.rb
+++ b/test/keela/config_file_test.rb
@@ -57,6 +57,40 @@ class ConfigFileTest < Minitest::Test
     assert_equal ["from_keela_yml/**/*.%<ext>s"], Keela.configuration.directory_patterns
   end
 
+  def test_loads_config_from_keela_directory
+    Dir.mkdir(".keela")
+    write_config(<<~YAML, filename: ".keela/config.yml")
+      directory_patterns:
+        - "from_keela_dir/**/*.%<ext>s"
+    YAML
+
+    Keela::ConfigFile.load
+
+    assert_equal ["from_keela_dir/**/*.%<ext>s"], Keela.configuration.directory_patterns
+  end
+
+  def test_keela_directory_takes_precedence_over_root_files
+    Dir.mkdir(".keela")
+    write_config(<<~YAML, filename: ".keela/config.yml")
+      directory_patterns:
+        - "from_keela_dir/**/*.%<ext>s"
+    YAML
+
+    write_config(<<~YAML, filename: "keela.yml")
+      directory_patterns:
+        - "from_keela_yml/**/*.%<ext>s"
+    YAML
+
+    write_config(<<~YAML, filename: ".keela.yml")
+      directory_patterns:
+        - "from_dot_keela_yml/**/*.%<ext>s"
+    YAML
+
+    Keela::ConfigFile.load
+
+    assert_equal ["from_keela_dir/**/*.%<ext>s"], Keela.configuration.directory_patterns
+  end
+
   def test_loads_extensions
     write_config(<<~YAML)
       extensions:


### PR DESCRIPTION
Add `.keela/config.yml` as the preferred location for the config file, completing the `.keela/` directory support added in #29.

**Lookup order:**
1. `.keela/config.yml` (new preferred)
2. `keela.yml`
3. `.keela.yml`

Now all Keela files can live in a single directory:

```
.keela/
├── config.yml
├── baseline.yml
└── excluded.yml
```

Existing root-level config files continue to work for backwards compatibility.