### PR TITLE
Exclude regex match operator from constant definitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    keela (0.2.1)
+    keela (0.2.2)
       parallel (~> 1.20)
       rainbow (~> 3.0)
       ruby-progressbar (~> 1.11)
@@ -26,7 +26,7 @@ DEPENDENCIES
 
 CHECKSUMS
   bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
-  keela (0.2.1)
+  keela (0.2.2)
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   parallel (1.28.0) sha256=33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a

--- a/lib/keela/strategies/constants.rb
+++ b/lib/keela/strategies/constants.rb
@@ -26,8 +26,8 @@ module Keela
         #   - Namespaced access: Foo::BAR
         #   - Class/module definitions
 
-        # First check it's not a comparison
-        return nil if line =~ /[!=]=/
+        # First check it's not a comparison or regex match operator
+        return nil if line =~ /[!=]=|=~/
 
         # Match the constant definition pattern
         return nil unless line =~ /^\s*([A-Z][A-Z0-9_]*)\s*=/

--- a/test/keela/strategies/constants_test.rb
+++ b/test/keela/strategies/constants_test.rb
@@ -99,6 +99,14 @@ class ConstantsStrategyTest < Minitest::Test
     assert_nil @strategy.extract_definition("if MAX_SIZE == 100")
   end
 
+  def test_does_not_match_not_equal_comparisons
+    assert_nil @strategy.extract_definition("if MAX_SIZE != 100")
+  end
+
+  def test_does_not_match_regex_match_operator
+    assert_nil @strategy.extract_definition("DATETIME_REGEX =~ @timeline_date_string")
+  end
+
   def test_does_not_match_usage_in_conditionals
     assert_nil @strategy.extract_definition("return if ENABLED")
   end


### PR DESCRIPTION
## Problem

The constants strategy was incorrectly detecting constant usages with the regex match operator (`=~`) as constant definitions. For example:

```ruby
DATETIME_REGEX =~ @timeline_date_string
```

Was matched as a definition because the filter only excluded `==` and `!=` comparisons, not `=~`. The pattern matched `DATETIME_REGEX =` before reaching the tilde.

This caused duplicate entries in the baseline when a constant was both defined and used with `=~` in the same file.

## Solution

Updated the filter regex from `/[!=]=/` to `/[!=]=|=~/` to also exclude lines containing the regex match operator.

## Testing

- Added test cases for `!=` and `=~` operators
- All 250 tests pass