### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3] - 2026-07-31
+
 ### Fixed
 
 - Constants strategy no longer detects regex match operator (`=~`) usage as constant definitions ([#31](https://github.com/kerrizor/keela/pull/31))
+
+### Changed
+
+- Stop tracking `Gemfile.lock` - gems should not commit their lockfile ([#33](https://github.com/kerrizor/keela/pull/33))
 
 ## [0.2.2] - 2026-07-27
 

--- a/lib/keela/version.rb
+++ b/lib/keela/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Keela
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
## Changes

### Fixed
- Constants strategy no longer detects regex match operator (`=~`) usage as constant definitions (#31)

### Changed
- Stop tracking `Gemfile.lock` - gems should not commit their lockfile (#33)