### PR TITLE
Add strategy-aware exclusion file format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Strategy-aware exclusion file format** - Exclusion files can now be organized by strategy (methods, scopes, etc.) to match the baseline file format. This allows excluding the same name in one strategy while flagging it in another. The legacy flat format is still supported for backward compatibility.
+
 ## [0.2.3] - 2026-07-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -271,21 +271,46 @@ This is useful for integrating with other tools, generating reports, or processi
 
 ## Exclusion File
 
-Some code appears unused but is actually called dynamically. Exclude it:
+Some code appears unused but is actually called dynamically. Exclude it using the **strategy-aware format** (recommended):
 
 ```yaml
-# .keela_excluded.yml
+# .keela/excluded.yml (strategy-aware format)
+methods:
+  app/models/user.rb:
+    - legacy_method: "Called via metaprogramming"
+    - callback_method: "Used as ActiveRecord callback"
+  app/helpers/application_helper.rb:
+    - helper_method: "Called from views dynamically"
+scopes:
+  app/models/user.rb:
+    - active: "Called dynamically via send()"
+```
+
+This format mirrors the baseline file structure and allows you to exclude the same name in one strategy while flagging it in another. For example, if you have both `scope :active` and `def active` in the same file, you can exclude them independently.
+
+### Legacy Flat Format
+
+The flat format is still supported for backward compatibility:
+
+```yaml
+# .keela_excluded.yml (legacy flat format)
 app/models/user.rb:
   - legacy_method: "Called via metaprogramming"
   - callback_method: "Used as ActiveRecord callback"
-app/helpers/application_helper.rb:
-  - helper_method: "Called from views dynamically"
 ```
 
-Then run with:
+**Note:** With the flat format, an exclusion applies to ALL strategies. If you exclude `active`, both the method and scope named `active` will be excluded.
+
+### Usage
 
 ```bash
-keela --excluded .keela_excluded.yml
+keela --excluded .keela/excluded.yml
+```
+
+Or configure in `keela.yml`:
+
+```yaml
+excluded_path: ".keela/excluded.yml"
 ```
 
 ## Ruby API

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -134,7 +134,16 @@ module Keela
       path = resolve_excluded_path
       return definitions unless path
 
-      excluded = YAML.load_file(path, symbolize_names: true) || {}
+      all_excluded = YAML.load_file(path, symbolize_names: true) || {}
+
+      # Support both formats:
+      # 1. Strategy-aware (new): { methods: { "file.rb": [{ name: "reason" }] } }
+      # 2. Flat (legacy): { "file.rb": [{ name: "reason" }] }
+      excluded = if all_excluded.key?(strategy.name.to_sym)
+                   all_excluded[strategy.name.to_sym] || {}
+                 else
+                   all_excluded # Legacy flat format
+                 end
 
       definitions.reject do |h|
         excluded_for_file = excluded[h[:file].to_sym]

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -522,6 +522,166 @@ class ScannerConfigurationValidationTest < Minitest::Test
     end
   end
 
+  # filter_excluded tests
+
+  def test_filter_excluded_with_strategy_aware_format
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        # Strategy-aware format: grouped by strategy name
+        excluded_content = <<~YAML
+          methods:
+            "app/models/user.rb":
+              - excluded_method: "Called via metaprogramming"
+        YAML
+        File.write("excluded.yml", excluded_content)
+
+        config = Keela::Configuration.new
+        config.excluded_path = "excluded.yml"
+        strategy = Keela::Strategies::Methods.new
+        scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+        definitions = [
+          { name: "excluded_method", file: "app/models/user.rb" },
+          { name: "kept_method", file: "app/models/user.rb" }
+        ]
+
+        result = scanner.send(:filter_excluded, definitions)
+
+        assert_equal 1, result.size
+        assert_equal "kept_method", result.first[:name]
+      end
+    end
+  end
+
+  def test_filter_excluded_with_legacy_flat_format
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        # Legacy flat format: no strategy grouping
+        excluded_content = <<~YAML
+          "app/models/user.rb":
+            - excluded_method: "Called via metaprogramming"
+        YAML
+        File.write("excluded.yml", excluded_content)
+
+        config = Keela::Configuration.new
+        config.excluded_path = "excluded.yml"
+        strategy = Keela::Strategies::Methods.new
+        scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+        definitions = [
+          { name: "excluded_method", file: "app/models/user.rb" },
+          { name: "kept_method", file: "app/models/user.rb" }
+        ]
+
+        result = scanner.send(:filter_excluded, definitions)
+
+        assert_equal 1, result.size
+        assert_equal "kept_method", result.first[:name]
+      end
+    end
+  end
+
+  def test_filter_excluded_strategy_aware_only_excludes_matching_strategy
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        # Same name excluded for scopes, but NOT for methods
+        excluded_content = <<~YAML
+          scopes:
+            "app/models/user.rb":
+              - active: "Used dynamically"
+        YAML
+        File.write("excluded.yml", excluded_content)
+
+        config = Keela::Configuration.new
+        config.excluded_path = "excluded.yml"
+
+        # Methods strategy should NOT exclude 'active'
+        methods_strategy = Keela::Strategies::Methods.new
+        methods_scanner = Keela::Scanner.new(strategy: methods_strategy, configuration: config)
+
+        definitions = [{ name: "active", file: "app/models/user.rb" }]
+        result = methods_scanner.send(:filter_excluded, definitions)
+
+        assert_equal 1, result.size, "Methods strategy should not exclude 'active' when only scopes has it excluded"
+
+        # Scopes strategy SHOULD exclude 'active'
+        scopes_strategy = Keela::Strategies::Scopes.new
+        scopes_scanner = Keela::Scanner.new(strategy: scopes_strategy, configuration: config)
+
+        result = scopes_scanner.send(:filter_excluded, definitions)
+
+        assert_equal 0, result.size, "Scopes strategy should exclude 'active'"
+      end
+    end
+  end
+
+  def test_filter_excluded_strategy_aware_with_multiple_strategies
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        # Different exclusions for different strategies
+        excluded_content = <<~YAML
+          methods:
+            "app/models/user.rb":
+              - method_only: "Excluded for methods"
+          scopes:
+            "app/models/user.rb":
+              - scope_only: "Excluded for scopes"
+        YAML
+        File.write("excluded.yml", excluded_content)
+
+        config = Keela::Configuration.new
+        config.excluded_path = "excluded.yml"
+
+        definitions = [
+          { name: "method_only", file: "app/models/user.rb" },
+          { name: "scope_only", file: "app/models/user.rb" },
+          { name: "neither", file: "app/models/user.rb" }
+        ]
+
+        # Methods strategy excludes method_only, keeps scope_only and neither
+        methods_scanner = Keela::Scanner.new(
+          strategy: Keela::Strategies::Methods.new,
+          configuration: config
+        )
+        result = methods_scanner.send(:filter_excluded, definitions)
+        names = result.map { |d| d[:name] }
+
+        assert_equal 2, result.size
+        assert_includes names, "scope_only"
+        assert_includes names, "neither"
+        refute_includes names, "method_only"
+
+        # Scopes strategy excludes scope_only, keeps method_only and neither
+        scopes_scanner = Keela::Scanner.new(
+          strategy: Keela::Strategies::Scopes.new,
+          configuration: config
+        )
+        result = scopes_scanner.send(:filter_excluded, definitions)
+        names = result.map { |d| d[:name] }
+
+        assert_equal 2, result.size
+        assert_includes names, "method_only"
+        assert_includes names, "neither"
+        refute_includes names, "scope_only"
+      end
+    end
+  end
+
+  def test_filter_excluded_returns_all_definitions_when_no_exclusion_file
+    config = Keela::Configuration.new
+    # No excluded_path set, no default files exist
+    scanner = Keela::Scanner.new(strategy: @strategy, configuration: config)
+
+    definitions = [
+      { name: "method_a", file: "app/models/user.rb" },
+      { name: "method_b", file: "app/models/user.rb" }
+    ]
+
+    result = scanner.send(:filter_excluded, definitions)
+
+    assert_equal 2, result.size
+  end
+
   # resolve_baseline_path tests
 
   def test_resolve_baseline_path_returns_configured_path_when_file_exists


### PR DESCRIPTION
## Summary

Support organizing exclusions by strategy (methods, scopes, etc.) to match the baseline file structure. This allows excluding the same name in one strategy while flagging it in another.

## Problem

Previously, the exclusion file used a flat format:

```yaml
app/models/user.rb:
  - active: "reason"
```

This excluded `active` from **all** strategies. If you had both `scope :active` and `def active` in the same file, you couldn't exclude one without the other.

## Solution

Add support for a strategy-aware format that mirrors the baseline structure:

```yaml
methods:
  app/models/user.rb:
    - active: "Called via metaprogramming"
scopes:
  app/models/user.rb:
    - active: "Used dynamically"
```

Now you can exclude the method while still flagging the scope (or vice versa).

## Backward Compatibility

The legacy flat format remains fully supported. When no strategy key is found in the exclusion file, the entire file is treated as exclusions for all strategies (existing behavior).

## Testing

- Added 5 new tests for `filter_excluded` behavior
- Tested against GitLab monolith (~12k method definitions)
- All 255 tests pass