### PR TITLE
Fix CLI options being overwritten by config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Strategy-aware exclusion file format** - Exclusion files can now be organized by strategy (methods, scopes, etc.) to match the baseline file format. This allows excluding the same name in one strategy while flagging it in another. The legacy flat format is still supported for backward compatibility.
 
+### Fixed
+
+- CLI options now correctly override config file settings ([#36](https://github.com/kerrizor/keela/pull/36))
+
 ## [0.2.3] - 2026-07-31
 
 ### Fixed

--- a/exe/keela
+++ b/exe/keela
@@ -13,6 +13,9 @@ options = {
   quiet: false
 }
 
+# Store CLI overrides separately so they can be applied after config file loads
+cli_overrides = {}
+
 OptionParser.new do |opts|
   opts.banner = "Usage: keela [options]"
 
@@ -45,23 +48,25 @@ OptionParser.new do |opts|
   end
 
   opts.on("--excluded PATH", "Path to YAML file of excluded items") do |path|
-    Keela.configuration.excluded_path = path
+    cli_overrides[:excluded_path] = path
   end
 
   opts.on("--baseline PATH", "Path to YAML baseline file (default: .keela_baseline.yml)") do |path|
-    Keela.configuration.baseline_path = path
+    cli_overrides[:baseline_path] = path
   end
 
   opts.on("--extensions EXTS", "Comma-separated file extensions to scan (default: rb,haml,erb)") do |exts|
-    Keela.configuration.extensions = exts.split(",").map(&:strip)
+    cli_overrides[:extensions] = exts.split(",").map(&:strip)
   end
 
   opts.on("--exclude PATTERN", "Glob pattern for files to exclude (can be used multiple times)") do |pattern|
-    Keela.configuration.exclude_patterns << pattern
+    cli_overrides[:exclude_patterns] ||= []
+    cli_overrides[:exclude_patterns] << pattern
   end
 
   opts.on("--include PATTERN", "Additional glob pattern to scan (can be used multiple times)") do |pattern|
-    Keela.configuration.include_patterns << pattern
+    cli_overrides[:include_patterns] ||= []
+    cli_overrides[:include_patterns] << pattern
   end
 
   opts.on("--config PATH", "-c", "Path to config file (default: keela.yml or .keela.yml)") do |path|
@@ -84,8 +89,12 @@ OptionParser.new do |opts|
 end.parse!
 
 # Load config file (keela.yml or .keela.yml) if present
-# CLI options override config file settings
 Keela::ConfigFile.load(path: options[:config_path])
+
+# Apply CLI overrides (these take precedence over config file)
+cli_overrides.each do |key, value|
+  Keela.configuration.public_send("#{key}=", value)
+end
 
 # Apply quiet mode if requested
 Keela.configuration.show_progress = false if options[:quiet]

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+require "fileutils"
+require "open3"
+
+class CLITest < Minitest::Test
+  KEELA_ROOT = File.expand_path("../..", __FILE__)
+  KEELA_EXE = File.join(KEELA_ROOT, "exe", "keela")
+  KEELA_LIB = File.join(KEELA_ROOT, "lib")
+
+  def test_cli_excluded_option_overrides_config_file
+    in_tmpdir do
+      setup_test_files
+
+      # Create a config file that sets excluded_path
+      File.write("keela.yml", <<~YAML)
+        excluded_path: "config_excluded.yml"
+      YAML
+
+      # Create the config file's exclusion (excludes nothing)
+      File.write("config_excluded.yml", "---\n{}")
+
+      # Create a CLI exclusion file that excludes our method
+      File.write("cli_excluded.yml", <<~YAML)
+        "app/models/user.rb":
+          - unused_method: "Excluded via CLI"
+      YAML
+
+      # Run without CLI override - should find unused_method
+      stdout, stderr, status = run_keela("--report", "--quiet")
+      assert status.success?, "Command should succeed: #{stderr}"
+      assert_match(/unused_method/, stdout, "Should find unused_method when using config file exclusions")
+
+      # Run with CLI override - should NOT find unused_method
+      stdout, stderr, status = run_keela("--report", "--quiet", "--excluded", "cli_excluded.yml")
+      assert status.success?, "Command should succeed: #{stderr}"
+      assert_match(/No unused methods/, stdout, "Should not find unused_method when CLI excludes it")
+    end
+  end
+
+  def test_cli_baseline_option_overrides_config_file
+    in_tmpdir do
+      setup_test_files
+
+      # Create a config file that sets baseline_path to a non-matching baseline
+      File.write("keela.yml", <<~YAML)
+        baseline_path: "config_baseline.yml"
+      YAML
+
+      # Create the config file's baseline (empty - will cause failure due to new unused)
+      File.write("config_baseline.yml", "---\n{}")
+
+      # Create a CLI baseline that includes our method (matches current state)
+      File.write("cli_baseline.yml", <<~YAML)
+        methods:
+          "app/models/user.rb":
+            - unused_method
+      YAML
+
+      # Run without CLI override - should fail (new unused code detected)
+      _stdout, _stderr, status = run_keela("--quiet")
+      refute status.success?, "Should fail when config baseline is empty but unused code exists"
+
+      # Run with CLI override pointing to baseline with our method
+      # Should pass (no new unused, no removed)
+      _stdout, stderr, status = run_keela("--quiet", "--baseline", "cli_baseline.yml")
+      assert status.success?, "Should pass when CLI baseline matches current state: #{stderr}"
+    end
+  end
+
+  def test_cli_extensions_option_overrides_config_file
+    in_tmpdir do
+      setup_test_files
+
+      # Create a config file that only scans .txt files
+      File.write("keela.yml", <<~YAML)
+        extensions:
+          - txt
+      YAML
+
+      # Run without CLI override - should find nothing (no .txt files)
+      stdout, stderr, status = run_keela("--report", "--quiet")
+      assert status.success?, "Command should succeed: #{stderr}"
+      assert_match(/No unused methods/, stdout, "Should find nothing when config limits to .txt")
+
+      # Run with CLI override - should find unused_method
+      stdout, stderr, status = run_keela("--report", "--quiet", "--extensions", "rb")
+      assert status.success?, "Command should succeed: #{stderr}"
+      assert_match(/unused_method/, stdout, "Should find unused_method when CLI sets .rb extension")
+    end
+  end
+
+  private
+
+  def in_tmpdir
+    Dir.mktmpdir do |tmpdir|
+      Dir.chdir(tmpdir) do
+        yield
+      end
+    end
+  end
+
+  def setup_test_files
+    FileUtils.mkdir_p("app/models")
+    File.write("app/models/user.rb", "def unused_method\nend\n")
+  end
+
+  def run_keela(*args)
+    env = { "RUBYLIB" => KEELA_LIB }
+    cmd = ["ruby", KEELA_EXE, "--type", "methods"] + args
+
+    Open3.capture3(env, *cmd)
+  end
+end


### PR DESCRIPTION
## Problem

CLI options like `--excluded` and `--baseline` were being set directly on `Keela.configuration` **before** the config file was loaded. This meant the config file would overwrite CLI options instead of CLI options taking precedence.

For example:
```bash
# This should use /tmp/my_exclusions.yml, but it was using the path from keela.yml
keela --excluded /tmp/my_exclusions.yml
```

## Solution

Store CLI options separately in a `cli_overrides` hash, then apply them **after** the config file loads:

```ruby
# Load config file first
Keela::ConfigFile.load(path: options[:config_path])

# Apply CLI overrides (these take precedence over config file)
cli_overrides.each do |key, value|
  Keela.configuration.public_send("#{key}=", value)
end
```

## Testing

Added integration tests that verify:
- `--excluded` overrides `excluded_path` from config file
- `--baseline` overrides `baseline_path` from config file  
- `--extensions` overrides `extensions` from config file

All 253 tests pass.