### PR TITLE
Share source files across strategies for ~33% speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Strategy-aware exclusion file format** - Exclusion files can now be organized by strategy (methods, scopes, etc.) to match the baseline file format. This allows excluding the same name in one strategy while flagging it in another. The legacy flat format is still supported for backward compatibility.
 
+### Changed
+
+- **Performance: Share source files across strategies** - When scanning multiple strategies, source files are now loaded once and shared, reducing scan time by ~33% on large codebases.
+
 ### Fixed
 
 - CLI options now correctly override config file settings ([#36](https://github.com/kerrizor/keela/pull/36))

--- a/exe/keela
+++ b/exe/keela
@@ -138,6 +138,9 @@ strategies = build_strategies(options[:types])
 # Share a single baseline across all strategies
 baseline = Keela::Baseline.new(Keela.configuration.baseline_path)
 
+# Load source files once and share across all strategies
+source_files = Keela::Scanner.load_source_files
+
 success = true
 results = {}
 
@@ -148,7 +151,7 @@ strategies.each_with_index do |strategy, index|
     puts Rainbow("=== Sniffing for unused #{strategy.name} ===").cyan.bright if strategies.size > 1
   end
 
-  scanner = Keela::Scanner.new(strategy: strategy, baseline: baseline)
+  scanner = Keela::Scanner.new(strategy: strategy, baseline: baseline, source_files: source_files)
   success &&= scanner.run(
     force_report: options[:force_report],
     update_baseline: options[:update_baseline],

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -10,11 +10,43 @@ module Keela
     DEFAULT_EXCLUDED_PATHS = [".keela/excluded.yml", "keela_excluded.yml"].freeze
     DEFAULT_BASELINE_PATHS = [".keela/baseline.yml", "keela_baseline.yml"].freeze
 
-    def initialize(strategy:, configuration: Keela.configuration, baseline: nil)
+    # Load source files once for sharing across multiple Scanner instances.
+    # Returns a hash of { filename => [lines] }.
+    def self.load_source_files(configuration: Keela.configuration)
+      source_files = {}
+      file_globs = build_file_globs(configuration)
+
+      Dir.glob(file_globs).each do |filename|
+        next if excluded_file?(filename, configuration)
+
+        source_files[filename] = File.readlines(filename)
+      end
+
+      source_files
+    end
+
+    def self.build_file_globs(configuration)
+      all_patterns = configuration.directory_patterns + configuration.include_patterns
+
+      configuration.extensions.flat_map do |ext|
+        all_patterns.map { |pattern| format(pattern, ext: ext) }
+      end
+    end
+
+    def self.excluded_file?(filename, configuration)
+      return false if configuration.exclude_patterns.empty?
+
+      configuration.exclude_patterns.any? do |pattern|
+        File.fnmatch?(pattern, filename, File::FNM_PATHNAME | File::FNM_EXTGLOB)
+      end
+    end
+
+    def initialize(strategy:, configuration: Keela.configuration, baseline: nil, source_files: nil)
       @strategy = strategy
       @configuration = configuration
       @baseline = baseline || Baseline.new(resolve_baseline_path)
-      @source_files = {}
+      @source_files = source_files || {}
+      @source_files_preloaded = !source_files.nil?
       @unused_collection = Hash.new { |hash, key| hash[key] = [] }
       @new_unused = []
       @removed = []
@@ -97,6 +129,8 @@ module Keela
     end
 
     def load_source_files
+      return if @source_files_preloaded
+
       Dir.glob(file_globs).each do |filename|
         next if excluded_file?(filename)
 

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -59,6 +59,70 @@ class ScannerTest < Minitest::Test
     assert @scanner.run
   end
 
+  def test_initializes_with_preloaded_source_files
+    preloaded = { "app/models/user.rb" => ["def foo\n", "end\n"] }
+    scanner = Keela::Scanner.new(strategy: @strategy, configuration: @config, source_files: preloaded)
+
+    assert_equal preloaded, scanner.source_files
+  end
+
+end
+
+class ScannerClassMethodsTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    FileUtils.mkdir_p("app/models")
+    FileUtils.mkdir_p("lib")
+    File.write("app/models/user.rb", "def user_method\nend\n")
+    File.write("lib/utils.rb", "def lib_method\nend\n")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_load_source_files_returns_hash_of_files
+    config = Keela::Configuration.new
+    source_files = Keela::Scanner.load_source_files(configuration: config)
+
+    assert_kind_of Hash, source_files
+    assert_includes source_files.keys, "app/models/user.rb"
+    assert_includes source_files.keys, "lib/utils.rb"
+  end
+
+  def test_load_source_files_contains_file_contents
+    config = Keela::Configuration.new
+    source_files = Keela::Scanner.load_source_files(configuration: config)
+
+    assert_equal ["def user_method\n", "end\n"], source_files["app/models/user.rb"]
+  end
+
+  def test_load_source_files_respects_exclude_patterns
+    config = Keela::Configuration.new
+    config.exclude_patterns = ["lib/**/*"]
+    source_files = Keela::Scanner.load_source_files(configuration: config)
+
+    assert_includes source_files.keys, "app/models/user.rb"
+    refute source_files.keys.any? { |f| f.start_with?("lib/") }
+  end
+
+  def test_preloaded_source_files_skips_loading
+    config = Keela::Configuration.new
+    preloaded = { "fake/file.rb" => ["# fake content\n"] }
+
+    strategy = Keela::Strategies::Methods.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config, source_files: preloaded)
+
+    # Run should use preloaded files, not load from disk
+    scanner.run(force_report: true, silent: true)
+
+    # Source files should still be the preloaded ones (not replaced by disk files)
+    assert_equal preloaded, scanner.source_files
+  end
 end
 
 class ScannerWithMockedFilesTest < Minitest::Test


### PR DESCRIPTION
## Problem

When scanning multiple strategies (e.g., `--type methods,scopes,constants`), source files were being loaded from disk separately for each strategy. On a large codebase (~24k files), this added 3-5 seconds per strategy.

## Solution

Load source files once via `Scanner.load_source_files()` and pass them to each Scanner instance.

## Performance

Tested on a large Rails project (~24k source files, 5 default strategies):

### Per-Strategy Breakdown

| Strategy | Before | After | Saved |
|----------|--------|-------|-------|
| methods | 8.1s | 3.7s | 4.4s |
| scopes | 4.4s | 0.9s | 3.5s |
| constants | 7.3s | 3.9s | 3.4s |
| delegations | 4.0s | 0.7s | 3.3s |
| attributes | 14.0s | 10.1s | 3.9s |

### Total Time

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Wall clock | 38.5s | 25.8s | **33% faster** |

The "After" total includes a one-time 4.5s file loading cost, shared across all strategies.

## Changes

- Add `Scanner.load_source_files` class method for loading files once
- Add `source_files` parameter to `Scanner#initialize`
- Skip `load_source_files` when files are preloaded
- Update CLI to load files once and share across strategies

## Backward Compatibility

Fully backward compatible. If `source_files` is not passed, Scanner loads files itself (existing behavior).