### PR TITLE
Add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **kerri@kerrizor.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,157 @@
+# Contributing to Keela
+
+Thanks for your interest in contributing to Keela! This document covers how to get started.
+
+## Development Setup
+
+```bash
+git clone https://github.com/kerrizor/keela.git
+cd keela
+bundle install
+```
+
+## Running Tests
+
+```bash
+bundle exec rake test
+```
+
+All tests must pass before submitting a PR.
+
+## Code Style
+
+- Use `frozen_string_literal: true` at the top of all Ruby files
+- Follow standard Ruby conventions
+- Keep methods small and focused
+- Add tests for new functionality
+
+## Adding a New Strategy
+
+The main extension point is creating new detection strategies. Each strategy defines how to find definitions and detect their usage.
+
+### 1. Create the Strategy Class
+
+Create a new file in `lib/keela/strategies/`:
+
+```ruby
+# frozen_string_literal: true
+
+module Keela
+  module Strategies
+    class MyStrategy < Strategy
+      def name
+        "my_strategy"  # Used in CLI: --type my_strategy
+      end
+
+      def definition_file_pattern
+        # Regex to match files that may contain definitions
+        %r{app/models}
+      end
+
+      def extract_definition(line)
+        # Return the definition name if this line defines one, nil otherwise
+        return nil unless line =~ /my_pattern\s+:(\w+)/
+
+        Regexp.last_match(1)
+      end
+
+      def usage_regex(name)
+        # Regex to detect usage of the given name
+        /#{Regexp.quote(name)}\W/
+      end
+
+      def skip_comments?
+        # Whether to skip lines starting with #
+        true
+      end
+    end
+  end
+end
+```
+
+### 2. Register the Strategy
+
+Add your strategy to `exe/keela`:
+
+```ruby
+STRATEGY_MAP = {
+  # ... existing strategies ...
+  my_strategy: Keela::Strategies::MyStrategy,
+}.freeze
+```
+
+If it should be included in `--type all`, add it to `DEFAULT_STRATEGIES`:
+
+```ruby
+DEFAULT_STRATEGIES = %i[methods scopes constants delegations attributes my_strategy].freeze
+```
+
+### 3. Add Tests
+
+Create `test/keela/strategies/my_strategy_test.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MyStrategyTest < Minitest::Test
+  def setup
+    @strategy = Keela::Strategies::MyStrategy.new
+  end
+
+  def test_name
+    assert_equal "my_strategy", @strategy.name
+  end
+
+  def test_extract_definition_matches_pattern
+    line = "my_pattern :foo"
+    assert_equal "foo", @strategy.extract_definition(line)
+  end
+
+  def test_extract_definition_returns_nil_for_non_match
+    line = "something_else :bar"
+    assert_nil @strategy.extract_definition(line)
+  end
+
+  def test_usage_regex_matches_usage
+    regex = @strategy.usage_regex("foo")
+    assert_match regex, "object.foo("
+    assert_match regex, "foo "
+  end
+end
+```
+
+### 4. Update Documentation
+
+- Add the strategy to the table in `README.md`
+- Add a changelog entry under `[Unreleased]`
+
+## Pull Request Process
+
+1. **Branch naming**: Use `your-username/description` (e.g., `kerrizor/add-callbacks-strategy`)
+
+2. **Changelog**: Add an entry to `CHANGELOG.md` under `[Unreleased]`:
+   ```markdown
+   ### Added
+   - **New strategy** - Description of what it detects
+   ```
+
+3. **Tests**: Ensure all tests pass with `bundle exec rake test`
+
+4. **PR description**: Explain what the change does and why
+
+## Strategy Interface Reference
+
+| Method | Required | Description |
+|--------|----------|-------------|
+| `name` | Yes | Human-readable name (used in CLI and output) |
+| `definition_file_pattern` | Yes | Regex to match files that may contain definitions |
+| `extract_definition(line)` | Yes | Extract definition name from a line, or `nil` |
+| `usage_regex(name)` | Yes | Regex to detect usage of the given name |
+| `skip_comments?` | No | Whether to skip `#` comment lines (default: `false`) |
+| `extract_definitions_from_file(filepath, lines)` | No | Custom file parsing (e.g., for YAML). Return `nil` for default line-by-line parsing |
+
+## Questions?
+
+Open an issue if you have questions or want to discuss a feature before implementing it.


### PR DESCRIPTION
Closes #23

## CONTRIBUTING.md

Covers:
- Development setup
- Running tests  
- Code style guidelines
- **How to add a new strategy** (with full example)
- Pull request process
- Strategy interface reference table

## CODE_OF_CONDUCT.md

Adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).