### PR TITLE
Fix multi-method delegate detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-method delegate declarations now detect all methods, not just the first ([#51](https://github.com/kerrizor/keela/pull/51))
+
 ## [0.3.0] - 2026-08-05
 
 ### Added

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -158,8 +158,9 @@ module Keela
         lines.flat_map do |line|
           next [] if strategy.skip_comments? && line.strip.start_with?("#")
 
-          name = strategy.extract_definition(line)
-          name ? [{ name: name, file: filename }] : []
+          result = strategy.extract_definition(line)
+          # Support both single name (String) and multiple names (Array)
+          Array(result).compact.map { |name| { name: name, file: filename } }
         end
       end
     end

--- a/lib/keela/strategies/delegations.rb
+++ b/lib/keela/strategies/delegations.rb
@@ -44,12 +44,8 @@ module Keela
           methods = methods.map { |m| "#{prefix}_#{m}" }
         end
 
-        # Return single string for single method (scanner expects this)
-        # For multiple methods, return first one only
-        # The scanner will create one definition entry per extract_definition call
-        # To handle multiple delegations per line, we'd need to change the scanner
-        # For now, return just the first method
-        methods.first
+        # Return all methods (scanner handles both single string and array)
+        methods.length == 1 ? methods.first : methods
       end
 
       def usage_regex(name)

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -814,4 +814,61 @@ class ScannerConfigurationValidationTest < Minitest::Test
   end
 end
 
+class ScannerMultiMethodDelegateTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    FileUtils.mkdir_p("app/models")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_detects_all_unused_methods_in_multi_method_delegate
+    File.write("app/models/order.rb", <<~RUBY)
+      class Order
+        delegate :name, :email, :phone, to: :user
+      end
+    RUBY
+
+    config = Keela::Configuration.new
+    strategy = Keela::Strategies::Delegations.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.run(force_report: true, silent: true)
+
+    unused = scanner.unused_collection["app/models/order.rb"]
+    assert_includes unused, "name"
+    assert_includes unused, "email"
+    assert_includes unused, "phone"
+  end
+
+  def test_detects_only_unused_methods_when_some_are_used
+    File.write("app/models/order.rb", <<~RUBY)
+      class Order
+        delegate :name, :email, :phone, to: :user
+
+        def display
+          name
+        end
+      end
+    RUBY
+
+    config = Keela::Configuration.new
+    strategy = Keela::Strategies::Delegations.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.run(force_report: true, silent: true)
+
+    unused = scanner.unused_collection["app/models/order.rb"]
+    refute_includes unused, "name"
+    assert_includes unused, "email"
+    assert_includes unused, "phone"
+  end
+end
+
 

--- a/test/keela/strategies/delegations_test.rb
+++ b/test/keela/strategies/delegations_test.rb
@@ -64,23 +64,20 @@ class DelegationsStrategyTest < Minitest::Test
   end
 
   # extract_definition tests - multiple methods
-  # Note: When multiple methods are delegated on one line, we return the first one.
-  # This is a limitation - ideally we'd return all, but the scanner expects single values.
 
-  def test_extracts_multiple_delegations_returns_first
-    # When multiple methods are delegated on one line, we return the first
+  def test_extracts_multiple_delegations
     result = @strategy.extract_definition("delegate :name, :email, to: :user")
-    assert_equal "name", result
+    assert_equal %w[name email], result
   end
 
-  def test_extracts_multiple_delegations_with_prefix_returns_first
+  def test_extracts_multiple_delegations_with_prefix
     result = @strategy.extract_definition("delegate :name, :email, to: :user, prefix: true")
-    assert_equal "user_name", result
+    assert_equal %w[user_name user_email], result
   end
 
-  def test_extracts_multiple_delegations_with_custom_prefix_returns_first
+  def test_extracts_multiple_delegations_with_custom_prefix
     result = @strategy.extract_definition("delegate :name, :email, to: :user, prefix: :owner")
-    assert_equal "owner_name", result
+    assert_equal %w[owner_name owner_email], result
   end
 
   # extract_definition tests - edge cases


### PR DESCRIPTION
Previously, delegate declarations with multiple methods only detected the first one:

```ruby
delegate :name, :email, :phone, to: :user
```

Would only flag `:name` as unused, silently ignoring `:email` and `:phone`.

**Changes:**
- Update Scanner to handle arrays from `extract_definition`
- Update Delegations strategy to return all methods
- Update tests to expect arrays for multi-method delegates
- Add integration tests for multi-method delegate scanning

**Note:** This fix applies to single-line delegate declarations. Multi-line delegates (with methods on separate lines) are a separate issue that would require joining continuation lines before parsing.

Closes #43