### PR TITLE
Add --verbose flag for debugging file scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Verbose mode** via `--verbose` flag to show files being scanned, glob patterns, and configuration for debugging ([#53](https://github.com/kerrizor/keela/pull/53))
+
 ### Fixed
 
 - Multi-method delegate declarations now detect all methods, not just the first ([#51](https://github.com/kerrizor/keela/pull/51))

--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ keela --format json
 keela --quiet
 keela -q
 
+# Show verbose debugging output (files scanned, patterns used)
+keela --verbose
+
 # Show version
 keela --version
 ```

--- a/exe/keela
+++ b/exe/keela
@@ -82,6 +82,10 @@ OptionParser.new do |opts|
     options[:quiet] = true
   end
 
+  opts.on("--verbose", "Show detailed debugging output (files scanned, patterns used)") do
+    options[:verbose] = true
+  end
+
   opts.on("-h", "--help", "Show this help") do
     puts opts
     exit
@@ -98,6 +102,9 @@ end
 
 # Apply quiet mode if requested
 Keela.configuration.show_progress = false if options[:quiet]
+
+# Apply verbose mode if requested
+Keela.configuration.verbose = true if options[:verbose]
 
 # Set default baseline path if not specified
 Keela.configuration.baseline_path ||= ".keela_baseline.yml"
@@ -140,6 +147,38 @@ baseline = Keela::Baseline.new(Keela.configuration.baseline_path)
 
 # Load source files once and share across all strategies
 source_files = Keela::Scanner.load_source_files
+
+# Show verbose output if requested
+if options[:verbose]
+  config = Keela.configuration
+  globs = Keela::Scanner.build_file_globs(config)
+
+  puts Rainbow("=== Verbose Mode ===").magenta.bright
+  puts
+  puts Rainbow("Configuration:").yellow
+  puts "  Extensions: #{config.extensions.join(', ')}"
+  puts "  Directory patterns: #{config.directory_patterns.join(', ')}"
+  puts "  Include patterns: #{config.include_patterns.empty? ? '(none)' : config.include_patterns.join(', ')}"
+  puts "  Exclude patterns: #{config.exclude_patterns.empty? ? '(none)' : config.exclude_patterns.join(', ')}"
+  puts
+  puts Rainbow("Resolved globs:").yellow
+  globs.each { |g| puts "  #{g}" }
+  puts
+  sorted_files = source_files.keys.sort
+  file_count = sorted_files.size
+  max_display = 50
+
+  puts Rainbow("Files to scan (#{file_count}):").yellow
+  # Show all files when piping (not a TTY), truncate for interactive use
+  if file_count <= max_display || !$stdout.tty?
+    sorted_files.each { |f| puts "  #{f}" }
+  else
+    sorted_files.first(max_display).each { |f| puts "  #{f}" }
+    puts "  ... and #{file_count - max_display} more files"
+    puts "  (pipe output to see full list: keela --verbose > files.txt)"
+  end
+  puts
+end
 
 success = true
 results = {}

--- a/lib/keela/configuration.rb
+++ b/lib/keela/configuration.rb
@@ -26,6 +26,9 @@ module Keela
     # Additional directory patterns to include (added to directory_patterns)
     attr_accessor :include_patterns
 
+    # Whether to show verbose debugging output
+    attr_accessor :verbose
+
     def initialize
       @extensions = %w[rb haml erb].freeze
       @directory_patterns = %w[
@@ -39,6 +42,7 @@ module Keela
       @show_progress = true
       @exclude_patterns = []
       @include_patterns = []
+      @verbose = false
     end
   end
 end

--- a/test/keela/configuration_test.rb
+++ b/test/keela/configuration_test.rb
@@ -83,4 +83,13 @@ class ConfigurationTest < Minitest::Test
     @config.include_patterns = %w[engines/**/*.%<ext>s custom/**/*.%<ext>s]
     assert_equal %w[engines/**/*.%<ext>s custom/**/*.%<ext>s], @config.include_patterns
   end
+
+  def test_default_verbose_is_false
+    refute @config.verbose
+  end
+
+  def test_verbose_is_configurable
+    @config.verbose = true
+    assert @config.verbose
+  end
 end


### PR DESCRIPTION
When debugging why certain files are or are not being scanned, use `--verbose` to see:

- **Configuration** — extensions, directory patterns, include/exclude patterns
- **Resolved glob patterns** — the actual globs being used
- **Files being scanned** — truncated to 50 in interactive mode, full list when piped

**Example output:**
```
=== Verbose Mode ===

Configuration:
  Extensions: rb, haml, erb
  Directory patterns: app/**/*.%<ext>s, lib/**/*.%<ext>s, config/**/*.%<ext>s
  Include patterns: (none)
  Exclude patterns: (none)

Resolved globs:
  app/**/*.rb
  lib/**/*.rb
  config/**/*.rb
  ...

Files to scan (24046):
  app/channels/application_cable/channel.rb
  app/channels/application_cable/connection.rb
  ...
  ... and 23996 more files
  (pipe output to see full list: keela --verbose > files.txt)
```

This helps diagnose issues like false positives caused by files not being included in the scan.

Closes #44