### PR TITLE
Make --quiet suppress all output, not just progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Verbose mode** via `--verbose` flag to show files being scanned, glob patterns, and configuration for debugging ([#53](https://github.com/kerrizor/keela/pull/53))
 
+### Changed
+
+- **`--quiet` now suppresses all output**, not just the progress bar. Use exit code for success/failure in scripts. ([#54](https://github.com/kerrizor/keela/pull/54))
+
 ### Fixed
 
 - Multi-method delegate declarations now detect all methods, not just the first ([#51](https://github.com/kerrizor/keela/pull/51))

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ keela --config path/to/keela.yml
 # Output as JSON (for CI integrations)
 keela --format json
 
-# Suppress progress bar (useful for CI and scripting)
+# Suppress all output (useful for CI and scripting, rely on exit code)
 keela --quiet
 keela -q
 

--- a/exe/keela
+++ b/exe/keela
@@ -184,9 +184,10 @@ success = true
 results = {}
 
 json_mode = options[:format] == :json
+silent_output = json_mode || options[:quiet]
 
 strategies.each_with_index do |strategy, index|
-  unless json_mode
+  unless silent_output
     puts Rainbow("=== Sniffing for unused #{strategy.name} ===").cyan.bright if strategies.size > 1
   end
 
@@ -194,13 +195,13 @@ strategies.each_with_index do |strategy, index|
   success &&= scanner.run(
     force_report: options[:force_report],
     update_baseline: options[:update_baseline],
-    silent: json_mode
+    silent: silent_output
   )
 
   # Collect results for JSON output
   results[strategy.name] = scanner.unused_collection.transform_values(&:to_a)
 
-  unless json_mode
+  unless silent_output
     puts if strategies.size > 1 && index < strategies.size - 1
   end
 end
@@ -208,7 +209,7 @@ end
 # Save baseline after all strategies have run
 if options[:update_baseline]
   baseline.save
-  puts Rainbow("Updated #{baseline.path}").green.bright unless json_mode
+  puts Rainbow("Updated #{baseline.path}").green.bright unless silent_output
 end
 
 # Output JSON if requested

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -29,12 +29,12 @@ class CLITest < Minitest::Test
       YAML
 
       # Run without CLI override - should find unused_method
-      stdout, stderr, status = run_keela("--report", "--quiet")
+      stdout, stderr, status = run_keela("--report")
       assert status.success?, "Command should succeed: #{stderr}"
       assert_match(/unused_method/, stdout, "Should find unused_method when using config file exclusions")
 
       # Run with CLI override - should NOT find unused_method
-      stdout, stderr, status = run_keela("--report", "--quiet", "--excluded", "cli_excluded.yml")
+      stdout, stderr, status = run_keela("--report", "--excluded", "cli_excluded.yml")
       assert status.success?, "Command should succeed: #{stderr}"
       assert_match(/No unused methods/, stdout, "Should not find unused_method when CLI excludes it")
     end
@@ -81,12 +81,12 @@ class CLITest < Minitest::Test
       YAML
 
       # Run without CLI override - should find nothing (no .txt files)
-      stdout, stderr, status = run_keela("--report", "--quiet")
+      stdout, stderr, status = run_keela("--report")
       assert status.success?, "Command should succeed: #{stderr}"
       assert_match(/No unused methods/, stdout, "Should find nothing when config limits to .txt")
 
       # Run with CLI override - should find unused_method
-      stdout, stderr, status = run_keela("--report", "--quiet", "--extensions", "rb")
+      stdout, stderr, status = run_keela("--report", "--extensions", "rb")
       assert status.success?, "Command should succeed: #{stderr}"
       assert_match(/unused_method/, stdout, "Should find unused_method when CLI sets .rb extension")
     end


### PR DESCRIPTION
**BREAKING CHANGE:** `--quiet` now suppresses all output, including the report and status messages. Use the exit code for success/failure in scripts.

Previously `--quiet` only suppressed the progress bar, which was inconsistent with user expectations. Now it truly means "quiet".

**Before:**
```bash
keela --quiet --update-baseline
# Still printed: "Updated .keela_baseline.yml"
# Still printed: report output
```

**After:**
```bash
keela --quiet --update-baseline
# No output, exit code 0 = success
```

Closes #48