### PR TITLE
Add --source-location flag to show line numbers in reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Verbose mode** via `--verbose` flag to show files being scanned, glob patterns, and configuration for debugging ([#53](https://github.com/kerrizor/keela/pull/53))
+- **Source location** via `--source-location` flag to show line numbers in reports for easier navigation ([#55](https://github.com/kerrizor/keela/pull/55))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ keela -q
 # Show verbose debugging output (files scanned, patterns used)
 keela --verbose
 
+# Show source location (file:line) for each unused item
+keela --source-location
+
 # Show version
 keela --version
 ```

--- a/exe/keela
+++ b/exe/keela
@@ -86,6 +86,10 @@ OptionParser.new do |opts|
     options[:verbose] = true
   end
 
+  opts.on("--source-location", "Show file:line for each unused item in reports") do
+    options[:source_location] = true
+  end
+
   opts.on("-h", "--help", "Show this help") do
     puts opts
     exit
@@ -105,6 +109,9 @@ Keela.configuration.show_progress = false if options[:quiet]
 
 # Apply verbose mode if requested
 Keela.configuration.verbose = true if options[:verbose]
+
+# Apply source location mode if requested
+Keela.configuration.source_location = true if options[:source_location]
 
 # Set default baseline path if not specified
 Keela.configuration.baseline_path ||= ".keela_baseline.yml"

--- a/lib/keela/configuration.rb
+++ b/lib/keela/configuration.rb
@@ -29,6 +29,9 @@ module Keela
     # Whether to show verbose debugging output
     attr_accessor :verbose
 
+    # Whether to show source location (file:line) in reports
+    attr_accessor :source_location
+
     def initialize
       @extensions = %w[rb haml erb].freeze
       @directory_patterns = %w[
@@ -43,6 +46,7 @@ module Keela
       @exclude_patterns = []
       @include_patterns = []
       @verbose = false
+      @source_location = false
     end
   end
 end

--- a/lib/keela/reporter.rb
+++ b/lib/keela/reporter.rb
@@ -11,12 +11,12 @@ module Keela
       @strategy_name = strategy_name
     end
 
-    def print_full_report(unused_collection, elapsed_time)
+    def print_full_report(unused_collection, elapsed_time, source_locations: {})
       unused_count = unused_collection.values.flatten.size
 
       if unused_count > 0
         puts "\nFound #{unused_count} unused #{strategy_name}:\n\n"
-        puts format_yaml(unused_collection)
+        puts format_report(unused_collection, source_locations)
         puts "\n"
       else
         puts Rainbow("No unused #{strategy_name} were found.").green.bright
@@ -25,8 +25,8 @@ module Keela
       puts "Finished in #{elapsed_time.round(2)} seconds."
     end
 
-    def print_diff_report(new_unused, removed, excluded_path:, baseline_path:)
-      print_new_unused(new_unused, excluded_path) unless new_unused.empty?
+    def print_diff_report(new_unused, removed, excluded_path:, baseline_path:, source_locations: {})
+      print_new_unused(new_unused, excluded_path, source_locations) unless new_unused.empty?
 
       if new_unused.size + removed.size > 0
         puts Rainbow("~" * 80).white.bright
@@ -36,13 +36,42 @@ module Keela
       print_removed(removed, baseline_path) unless removed.empty?
     end
 
+    def format_report(collection, source_locations = {})
+      if source_locations.empty?
+        format_yaml(collection)
+      else
+        format_with_locations(collection, source_locations)
+      end
+    end
+
     def format_yaml(collection)
       indent_yaml_list_items(collection.sort.to_h.to_yaml)
     end
 
     private
 
-    def print_new_unused(new_unused, excluded_path)
+    def format_with_locations(collection, source_locations)
+      # Calculate max name length for alignment
+      all_names = collection.values.flatten
+      max_name_len = all_names.map(&:length).max || 0
+      padding = max_name_len + 6  # "  - " prefix + 2 spaces
+
+      lines = ["---"]
+      collection.sort.each do |file, names|
+        lines << "#{file}:"
+        names.each do |name|
+          line_num = source_locations["#{file}:#{name}"]
+          if line_num
+            lines << "  - #{name}".ljust(padding) + "#{file}:#{line_num}"
+          else
+            lines << "  - #{name}"
+          end
+        end
+      end
+      lines.join("\n")
+    end
+
+    def print_new_unused(new_unused, excluded_path, source_locations = {})
       error = <<~MESSAGE
         We have detected #{new_unused.size} newly unused #{strategy_name}.
 
@@ -50,7 +79,7 @@ module Keela
       MESSAGE
 
       puts Rainbow(error).red.bright
-      puts Rainbow(format_yaml(parse_diff(new_unused))).red.bright
+      puts Rainbow(format_report(parse_diff(new_unused), source_locations)).red.bright
     end
 
     def print_removed(removed, baseline_path)

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -5,7 +5,7 @@ require "yaml"
 
 module Keela
   class Scanner
-    attr_reader :strategy, :configuration, :baseline, :source_files, :unused_collection, :new_unused, :removed
+    attr_reader :strategy, :configuration, :baseline, :source_files, :unused_collection, :source_locations, :new_unused, :removed
 
     DEFAULT_EXCLUDED_PATHS = [".keela/excluded.yml", "keela_excluded.yml"].freeze
     DEFAULT_BASELINE_PATHS = [".keela/baseline.yml", "keela_baseline.yml"].freeze
@@ -48,6 +48,7 @@ module Keela
       @source_files = source_files || {}
       @source_files_preloaded = !source_files.nil?
       @unused_collection = Hash.new { |hash, key| hash[key] = [] }
+      @source_locations = {}  # { "file:name" => line_number }
       @new_unused = []
       @removed = []
     end
@@ -70,7 +71,7 @@ module Keela
 
       if report_mode
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
-        reporter.print_full_report(unused_collection, elapsed) unless silent
+        reporter.print_full_report(unused_collection, elapsed, source_locations: source_locations) unless silent
         if update_baseline
           baseline.set(strategy.name, unused_collection)
           # Note: caller is responsible for calling baseline.save after all strategies run
@@ -85,7 +86,8 @@ module Keela
           new_unused,
           removed,
           excluded_path: resolve_excluded_path || ".keela/excluded.yml",
-          baseline_path: baseline.path
+          baseline_path: baseline.path,
+          source_locations: source_locations
         )
       end
 
@@ -155,12 +157,17 @@ module Keela
         next custom_definitions if custom_definitions
 
         # Default: line-by-line parsing
-        lines.flat_map do |line|
+        track_lines = configuration.source_location
+        lines.each_with_index.flat_map do |line, index|
           next [] if strategy.skip_comments? && line.strip.start_with?("#")
 
           result = strategy.extract_definition(line)
           # Support both single name (String) and multiple names (Array)
-          Array(result).compact.map { |name| { name: name, file: filename } }
+          Array(result).compact.map do |name|
+            definition = { name: name, file: filename }
+            definition[:line] = index + 1 if track_lines
+            definition
+          end
         end
       end
     end
@@ -212,6 +219,9 @@ module Keela
 
       unused.each do |unused_def|
         @unused_collection[unused_def[:file]] << unused_def[:name]
+        if unused_def[:line]
+          @source_locations["#{unused_def[:file]}:#{unused_def[:name]}"] = unused_def[:line]
+        end
       end
     end
 

--- a/test/keela/configuration_test.rb
+++ b/test/keela/configuration_test.rb
@@ -92,4 +92,13 @@ class ConfigurationTest < Minitest::Test
     @config.verbose = true
     assert @config.verbose
   end
+
+  def test_default_source_location_is_false
+    refute @config.source_location
+  end
+
+  def test_source_location_is_configurable
+    @config.source_location = true
+    assert @config.source_location
+  end
 end


### PR DESCRIPTION
When debugging or navigating to unused code, use `--source-location` to see file:line references:

```bash
keela --report --source-location
```

**Output:**
```
app/models/order.rb:
  - unused_method               app/models/order.rb:6
  - another_method              app/models/order.rb:12
```

**Design decisions:**
- Line numbers are only tracked when the flag is set (no overhead by default)
- Not stored in baseline/exclusion files to avoid drift issues when code moves
- Output is aligned for readability

Closes #41