### PR TITLE
Add --test-exclusions flag to validate exclusion file entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Verbose mode** via `--verbose` flag to show files being scanned, glob patterns, and configuration for debugging ([#53](https://github.com/kerrizor/keela/pull/53))
 - **Source location** via `--source-location` flag to show line numbers in reports for easier navigation ([#55](https://github.com/kerrizor/keela/pull/55))
+- **Exclusion validation** via `--test-exclusions` flag to find stale entries in exclusion files ([#56](https://github.com/kerrizor/keela/pull/56))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ keela --verbose
 # Show source location (file:line) for each unused item
 keela --source-location
 
+# Validate exclusion file entries (find stale exclusions)
+keela --test-exclusions
+
 # Show version
 keela --version
 ```

--- a/exe/keela
+++ b/exe/keela
@@ -90,6 +90,10 @@ OptionParser.new do |opts|
     options[:source_location] = true
   end
 
+  opts.on("--test-exclusions", "Validate that exclusion file entries match actual definitions") do
+    options[:test_exclusions] = true
+  end
+
   opts.on("-h", "--help", "Show this help") do
     puts opts
     exit
@@ -115,6 +119,21 @@ Keela.configuration.source_location = true if options[:source_location]
 
 # Set default baseline path if not specified
 Keela.configuration.baseline_path ||= ".keela_baseline.yml"
+
+# Handle --test-exclusions mode
+if options[:test_exclusions]
+  excluded_path = Keela.configuration.excluded_path ||
+                  Keela::Scanner::DEFAULT_EXCLUDED_PATHS.find { |p| File.exist?(p) }
+
+  unless excluded_path
+    warn "Error: No exclusion file found. Specify with --excluded PATH"
+    exit 1
+  end
+
+  validator = Keela::ExclusionValidator.new(excluded_path)
+  success = validator.validate
+  exit(success ? 0 : 1)
+end
 
 STRATEGY_MAP = {
   methods: Keela::Strategies::Methods,

--- a/lib/keela.rb
+++ b/lib/keela.rb
@@ -13,6 +13,7 @@ require_relative "keela/strategies/i18n_keys"
 require_relative "keela/reporter"
 require_relative "keela/baseline"
 require_relative "keela/scanner"
+require_relative "keela/exclusion_validator"
 
 module Keela
   class Error < StandardError; end

--- a/lib/keela/exclusion_validator.rb
+++ b/lib/keela/exclusion_validator.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "yaml"
+require "rainbow"
+
+module Keela
+  class ExclusionValidator
+    STRATEGY_MAP = {
+      methods: Strategies::Methods,
+      scopes: Strategies::Scopes,
+      constants: Strategies::Constants,
+      delegations: Strategies::Delegations,
+      attributes: Strategies::Attributes,
+      i18n_keys: Strategies::I18nKeys
+    }.freeze
+
+    attr_reader :excluded_path, :results
+
+    def initialize(excluded_path)
+      @excluded_path = excluded_path
+      @results = { valid: [], stale: [] }
+    end
+
+    def validate
+      unless File.exist?(excluded_path)
+        puts Rainbow("Exclusion file not found: #{excluded_path}").red
+        return false
+      end
+
+      all_excluded = YAML.load_file(excluded_path, symbolize_names: true) || {}
+
+      if all_excluded.empty?
+        puts Rainbow("Exclusion file is empty: #{excluded_path}").yellow
+        return true
+      end
+
+      puts "Validating exclusions in #{excluded_path}...\n\n"
+
+      # Detect format: strategy-aware or legacy flat
+      if strategy_aware_format?(all_excluded)
+        validate_strategy_aware(all_excluded)
+      else
+        validate_legacy_flat(all_excluded)
+      end
+
+      print_results
+      results[:stale].empty?
+    end
+
+    private
+
+    def strategy_aware_format?(data)
+      data.keys.any? { |k| STRATEGY_MAP.key?(k) }
+    end
+
+    def validate_strategy_aware(all_excluded)
+      all_excluded.each do |strategy_name, files|
+        next unless STRATEGY_MAP.key?(strategy_name)
+
+        strategy = STRATEGY_MAP[strategy_name].new
+        validate_files(strategy, strategy_name, files || {})
+      end
+    end
+
+    def validate_legacy_flat(all_excluded)
+      # Legacy format applies to all strategies, but we'll check against methods
+      strategy = Strategies::Methods.new
+      validate_files(strategy, :methods, all_excluded)
+    end
+
+    def validate_files(strategy, strategy_name, files)
+      files.each do |file_path, entries|
+        file_str = file_path.to_s
+        entries ||= []
+
+        entries.each do |entry|
+          name = entry.keys.first.to_s
+          reason = entry.values.first
+
+          if !File.exist?(file_str)
+            results[:stale] << {
+              strategy: strategy_name,
+              file: file_str,
+              name: name,
+              reason: reason,
+              error: "file not found"
+            }
+          elsif !definition_exists?(strategy, file_str, name)
+            results[:stale] << {
+              strategy: strategy_name,
+              file: file_str,
+              name: name,
+              reason: reason,
+              error: "no definition found"
+            }
+          else
+            results[:valid] << {
+              strategy: strategy_name,
+              file: file_str,
+              name: name,
+              reason: reason
+            }
+          end
+        end
+      end
+    end
+
+    def definition_exists?(strategy, file_path, name)
+      return false unless File.exist?(file_path)
+
+      lines = File.readlines(file_path)
+
+      # Check custom extraction first (for I18n YAML files)
+      custom_defs = strategy.extract_definitions_from_file(file_path, lines)
+      if custom_defs
+        return custom_defs.any? { |d| d[:name] == name }
+      end
+
+      # Default line-by-line extraction
+      lines.any? do |line|
+        next if strategy.skip_comments? && line.strip.start_with?("#")
+
+        result = strategy.extract_definition(line)
+        Array(result).compact.include?(name)
+      end
+    end
+
+    def print_results
+      if results[:valid].any?
+        puts Rainbow("✅ Valid exclusions (#{results[:valid].size}):").green.bright
+        group_by_strategy(results[:valid]).each do |strategy, entries|
+          puts "   #{strategy}:"
+          entries.each do |e|
+            puts "     #{e[:file]}:#{e[:name]}"
+          end
+        end
+        puts
+      end
+
+      if results[:stale].any?
+        puts Rainbow("⚠️  Stale exclusions found (#{results[:stale].size}):").yellow.bright
+        puts
+        group_by_strategy(results[:stale]).each do |strategy, entries|
+          puts "   #{strategy}:"
+          entries.each do |e|
+            puts "     #{e[:file]}:#{e[:name]} — #{e[:error]}"
+          end
+        end
+        puts
+        puts "Consider removing stale exclusions from #{excluded_path}"
+      else
+        puts Rainbow("All exclusions are valid!").green.bright
+      end
+    end
+
+    def group_by_strategy(entries)
+      entries.group_by { |e| e[:strategy] }
+    end
+  end
+end

--- a/test/keela/exclusion_validator_test.rb
+++ b/test/keela/exclusion_validator_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+require "fileutils"
+
+class ExclusionValidatorTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    FileUtils.mkdir_p("app/models")
+    File.write("app/models/user.rb", <<~RUBY)
+      class User
+        def existing_method
+        end
+
+        scope :active, -> { where(active: true) }
+      end
+    RUBY
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_validates_existing_method
+    File.write("excluded.yml", <<~YAML)
+      methods:
+        "app/models/user.rb":
+          - existing_method: "reason"
+    YAML
+
+    validator = Keela::ExclusionValidator.new("excluded.yml")
+
+    assert_output(/Valid exclusions/) do
+      result = validator.validate
+      assert result
+    end
+
+    assert_equal 1, validator.results[:valid].size
+    assert_empty validator.results[:stale]
+  end
+
+  def test_detects_stale_method
+    File.write("excluded.yml", <<~YAML)
+      methods:
+        "app/models/user.rb":
+          - nonexistent_method: "reason"
+    YAML
+
+    validator = Keela::ExclusionValidator.new("excluded.yml")
+
+    assert_output(/Stale exclusions found/) do
+      result = validator.validate
+      refute result
+    end
+
+    assert_empty validator.results[:valid]
+    assert_equal 1, validator.results[:stale].size
+    assert_equal "no definition found", validator.results[:stale].first[:error]
+  end
+
+  def test_detects_missing_file
+    File.write("excluded.yml", <<~YAML)
+      methods:
+        "app/models/nonexistent.rb":
+          - some_method: "reason"
+    YAML
+
+    validator = Keela::ExclusionValidator.new("excluded.yml")
+
+    assert_output(/Stale exclusions found/) do
+      result = validator.validate
+      refute result
+    end
+
+    assert_equal "file not found", validator.results[:stale].first[:error]
+  end
+
+  def test_validates_scope
+    File.write("excluded.yml", <<~YAML)
+      scopes:
+        "app/models/user.rb":
+          - active: "reason"
+    YAML
+
+    validator = Keela::ExclusionValidator.new("excluded.yml")
+
+    assert_output(/Valid exclusions/) do
+      result = validator.validate
+      assert result
+    end
+
+    assert_equal 1, validator.results[:valid].size
+  end
+
+  def test_returns_false_for_missing_exclusion_file
+    validator = Keela::ExclusionValidator.new("nonexistent.yml")
+
+    assert_output(/not found/) do
+      result = validator.validate
+      refute result
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `--test-exclusions` flag that validates exclusion file entries against actual definitions in the codebase. This helps find stale exclusions from renamed methods, deleted code, typos, or moved files.

## Usage

```bash
keela --test-exclusions
```

## Output

```
Validating exclusions in .keela/excluded.yml...

✅ Valid exclusions (2):
   methods:
     app/models/user.rb:legacy_method
   delegations:
     app/models/order.rb:name_with_article

⚠️  Stale exclusions found (1):
   methods:
     app/models/user.rb:old_method — no definition found

Consider removing stale exclusions from .keela/excluded.yml
```

## Exit Codes

- **0**: All exclusions are valid
- **1**: Stale exclusions found (useful for CI integration)

## Implementation

- New `Keela::ExclusionValidator` class handles validation logic
- Supports both strategy-aware and legacy flat exclusion formats
- Checks for missing files and missing definitions
- Groups results by strategy for clear output

## Testing

- 5 new tests covering valid entries, stale methods, missing files, scope validation, and missing exclusion file

Closes #47