### PR TITLE
Add TOON output format support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Verbose mode** via `--verbose` flag to show files being scanned, glob patterns, and configuration for debugging ([#53](https://github.com/kerrizor/keela/pull/53))
 - **Source location** via `--source-location` flag to show line numbers in reports for easier navigation ([#55](https://github.com/kerrizor/keela/pull/55))
 - **Exclusion validation** via `--test-exclusions` flag to find stale entries in exclusion files ([#56](https://github.com/kerrizor/keela/pull/56))
+- **TOON output format** via `--format toon` for token-efficient LLM-friendly output ([#58](https://github.com/kerrizor/keela/pull/58))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -294,13 +294,16 @@ The workflow:
 2. **CI runs**: `keela` compares against baseline, fails on new dead code
 3. **After cleanup**: Run `keela --update-baseline` to update the baseline
 
-### JSON Output
+### Structured Output Formats
 
-Use `--format json` for machine-readable output:
+Use `--format` for machine-readable output:
 
 ```bash
-keela --format json --report
+keela --format json --report   # JSON output
+keela --format toon --report   # TOON output (token-efficient for LLMs)
 ```
+
+#### JSON
 
 ```json
 {
@@ -323,7 +326,25 @@ keela --format json --report
 }
 ```
 
-This is useful for integrating with other tools, generating reports, or processing results programmatically.
+#### TOON
+
+[TOON (Token-Oriented Object Notation)](https://toonformat.dev/) is a compact format optimized for LLM prompts, using ~40-50% fewer tokens than JSON:
+
+```
+strategies[2]: methods,scopes
+unused:
+  methods:
+    "app/models/user.rb"[2]: unused_method,old_helper
+  scopes:
+    "app/models/post.rb"[1]: inactive
+summary:
+  total: 3
+  by_strategy:
+    methods: 2
+    scopes: 1
+```
+
+These formats are useful for integrating with other tools, generating reports, processing results programmatically, or including in LLM context windows.
 
 ## Exclusion File
 

--- a/exe/keela
+++ b/exe/keela
@@ -43,7 +43,7 @@ OptionParser.new do |opts|
     options[:update_baseline] = true
   end
 
-  opts.on("--format FORMAT", %i[text json], "Output format: text (default) or json") do |format|
+  opts.on("--format FORMAT", %i[text json toon], "Output format: text (default), json, or toon") do |format|
     options[:format] = format
   end
 
@@ -209,8 +209,8 @@ end
 success = true
 results = {}
 
-json_mode = options[:format] == :json
-silent_output = json_mode || options[:quiet]
+structured_output = Keela::Formatters.structured_format?(options[:format])
+silent_output = structured_output || options[:quiet]
 
 strategies.each_with_index do |strategy, index|
   unless silent_output
@@ -224,7 +224,7 @@ strategies.each_with_index do |strategy, index|
     silent: silent_output
   )
 
-  # Collect results for JSON output
+  # Collect results for structured output formats
   results[strategy.name] = scanner.unused_collection.transform_values(&:to_a)
 
   unless silent_output
@@ -238,23 +238,11 @@ if options[:update_baseline]
   puts Rainbow("Updated #{baseline.path}").green.bright unless silent_output
 end
 
-# Output JSON if requested
-if json_mode
-  require "json"
-
-  total = results.values.flat_map(&:values).flatten.size
-  by_strategy = results.transform_values { |files| files.values.flatten.size }
-
-  output = {
-    strategies: strategies.map(&:name),
-    unused: results.reject { |_, v| v.empty? },
-    summary: {
-      total: total,
-      by_strategy: by_strategy.reject { |_, v| v.zero? }
-    }
-  }
-
-  puts JSON.pretty_generate(output)
+# Output structured format if requested
+if structured_output
+  formatter_class = Keela::Formatters.for(options[:format])
+  formatter = formatter_class.new(results: results, strategies: strategies)
+  puts formatter.format
 end
 
 exit(success ? 0 : 1)

--- a/keela.gemspec
+++ b/keela.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "parallel", "~> 1.20"
   s.add_dependency "rainbow", "~> 3.0"
   s.add_dependency "ruby-progressbar", "~> 1.11"
+  s.add_dependency "toon-ruby", "~> 0.1"
 
   s.metadata = {
     "homepage_uri" => s.homepage,

--- a/lib/keela.rb
+++ b/lib/keela.rb
@@ -14,6 +14,7 @@ require_relative "keela/reporter"
 require_relative "keela/baseline"
 require_relative "keela/scanner"
 require_relative "keela/exclusion_validator"
+require_relative "keela/formatters"
 
 module Keela
   class Error < StandardError; end

--- a/lib/keela/formatters.rb
+++ b/lib/keela/formatters.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "formatters/base"
+require_relative "formatters/json"
+require_relative "formatters/toon"
+
+module Keela
+  module Formatters
+    REGISTRY = {
+      json: Json,
+      toon: Toon
+    }.freeze
+
+    def self.for(format)
+      REGISTRY[format]
+    end
+
+    def self.structured_format?(format)
+      REGISTRY.key?(format)
+    end
+  end
+end

--- a/lib/keela/formatters/base.rb
+++ b/lib/keela/formatters/base.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Keela
+  module Formatters
+    class Base
+      attr_reader :results, :strategies
+
+      def initialize(results:, strategies:)
+        @results = results
+        @strategies = strategies
+      end
+
+      def format
+        raise NotImplementedError, "Subclasses must implement #format"
+      end
+
+      private
+
+      def total_count
+        results.values.flat_map(&:values).flatten.size
+      end
+
+      def by_strategy_counts
+        results.transform_values { |files| files.values.flatten.size }
+                .reject { |_, v| v.zero? }
+      end
+
+      def non_empty_results
+        results.reject { |_, v| v.empty? }
+      end
+    end
+  end
+end

--- a/lib/keela/formatters/json.rb
+++ b/lib/keela/formatters/json.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Keela
+  module Formatters
+    class Json < Base
+      def format
+        output = {
+          strategies: strategies.map(&:name),
+          unused: non_empty_results,
+          summary: {
+            total: total_count,
+            by_strategy: by_strategy_counts
+          }
+        }
+
+        JSON.pretty_generate(output)
+      end
+    end
+  end
+end

--- a/lib/keela/formatters/toon.rb
+++ b/lib/keela/formatters/toon.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "toon"
+
+module Keela
+  module Formatters
+    class Toon < Base
+      def format
+        output = {
+          "strategies" => strategies.map(&:name),
+          "unused" => non_empty_results.transform_keys(&:to_s),
+          "summary" => {
+            "total" => total_count,
+            "by_strategy" => by_strategy_counts.transform_keys(&:to_s)
+          }
+        }
+
+        ::Toon.encode(output)
+      end
+    end
+  end
+end

--- a/test/keela/formatters_test.rb
+++ b/test/keela/formatters_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "json"
+
+class FormattersTest < Minitest::Test
+  FakeStrategy = Struct.new(:name)
+
+  def setup
+    @results = {
+      "methods" => {
+        "app/models/user.rb" => ["foo", "bar"],
+        "app/models/post.rb" => ["baz"]
+      },
+      "scopes" => {}
+    }
+    @strategies = [
+      FakeStrategy.new("methods"),
+      FakeStrategy.new("scopes")
+    ]
+  end
+
+  def test_structured_format_returns_true_for_json
+    assert Keela::Formatters.structured_format?(:json)
+  end
+
+  def test_structured_format_returns_true_for_toon
+    assert Keela::Formatters.structured_format?(:toon)
+  end
+
+  def test_structured_format_returns_false_for_text
+    refute Keela::Formatters.structured_format?(:text)
+  end
+
+  def test_structured_format_returns_false_for_nil
+    refute Keela::Formatters.structured_format?(nil)
+  end
+
+  def test_for_returns_json_formatter
+    assert_equal Keela::Formatters::Json, Keela::Formatters.for(:json)
+  end
+
+  def test_for_returns_toon_formatter
+    assert_equal Keela::Formatters::Toon, Keela::Formatters.for(:toon)
+  end
+
+  def test_for_returns_nil_for_unknown
+    assert_nil Keela::Formatters.for(:unknown)
+  end
+
+  def test_json_formatter_output
+    formatter = Keela::Formatters::Json.new(results: @results, strategies: @strategies)
+    output = JSON.parse(formatter.format)
+
+    assert_equal %w[methods scopes], output["strategies"]
+    assert_equal 3, output["summary"]["total"]
+    assert_equal({ "methods" => 3 }, output["summary"]["by_strategy"])
+    assert_equal %w[foo bar], output["unused"]["methods"]["app/models/user.rb"]
+  end
+
+  def test_toon_formatter_output
+    formatter = Keela::Formatters::Toon.new(results: @results, strategies: @strategies)
+    output = formatter.format
+
+    assert_includes output, "strategies[2]: methods,scopes"
+    assert_includes output, "total: 3"
+    assert_includes output, "methods: 3"
+  end
+
+  def test_json_formatter_excludes_empty_results
+    formatter = Keela::Formatters::Json.new(results: @results, strategies: @strategies)
+    output = JSON.parse(formatter.format)
+
+    refute output["unused"].key?("scopes")
+  end
+
+  def test_toon_formatter_excludes_empty_results
+    formatter = Keela::Formatters::Toon.new(results: @results, strategies: @strategies)
+    output = formatter.format
+
+    # scopes should not appear in unused section
+    refute_match(/unused:.*scopes:/m, output)
+  end
+end


### PR DESCRIPTION
## Summary

Adds `--format toon` option for token-efficient LLM-friendly output using [TOON (Token-Oriented Object Notation)](https://toonformat.dev/), which uses ~40-50% fewer tokens than JSON while maintaining the same data structure.

## Usage

```bash
keela --format toon --report
```

## Example Output

```
strategies[2]: methods,scopes
unused:
  methods:
    "app/models/user.rb"[2]: foo,bar
summary:
  total: 2
  by_strategy:
    methods: 2
```

## Why TOON?

As LLM-assisted development workflows become more common, outputting Keela results in a token-efficient format makes it easier to include unused code reports in LLM context windows without consuming excessive tokens.

## Implementation

Refactors output formatting into a proper `Formatters` module:

- `Keela::Formatters::Base` - shared logic for structured output
- `Keela::Formatters::Json` - existing JSON output (unchanged behavior)
- `Keela::Formatters::Toon` - new TOON output
- `Keela::Formatters.for(:format)` - factory method
- `Keela::Formatters.structured_format?(:format)` - check if format needs silent scanning mode

This architecture makes it easy to add more output formats in the future.

## Dependencies

Adds `toon-ruby` gem (~0.1) as a dependency.

Closes #49