### PR TITLE
Add configurable definition_paths per strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Source location** via `--source-location` flag to show line numbers in reports for easier navigation ([#55](https://github.com/kerrizor/keela/pull/55))
 - **Exclusion validation** via `--test-exclusions` flag to find stale entries in exclusion files ([#56](https://github.com/kerrizor/keela/pull/56))
 - **TOON output format** via `--format toon` for token-efficient LLM-friendly output ([#58](https://github.com/kerrizor/keela/pull/58))
+- **Configurable definition paths** per strategy via `strategies.<name>.definition_paths` in config file ([#59](https://github.com/kerrizor/keela/pull/59))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -226,9 +226,38 @@ include_patterns:
 
 excluded_path: ".keela_excluded.yml"
 baseline_path: ".keela_baseline.yml"
+
+# Per-strategy configuration
+strategies:
+  methods:
+    definition_paths:
+      - app/helpers
+      - app/models
+      - lib/
 ```
 
 Keela automatically loads `keela.yml` or `.keela.yml` from the current directory. Use `--config` to specify a different path.
+
+### Customizing Definition Paths Per Strategy
+
+By default, each strategy looks for definitions in specific directories (e.g., `methods` looks in `app/helpers` and `app/models`). You can customize this per-strategy:
+
+```yaml
+# keela.yml
+strategies:
+  methods:
+    definition_paths:
+      - app/helpers
+      - app/models
+      - lib/
+      - ee/app/models
+  scopes:
+    definition_paths:
+      - app/models
+      - ee/app/models
+```
+
+This is useful when your project has code in non-standard locations (like `lib/` or enterprise edition directories) that you want Keela to check for unused definitions.
 
 ### Customizing Which Files to Scan
 

--- a/lib/keela/config_file.rb
+++ b/lib/keela/config_file.rb
@@ -17,6 +17,7 @@ module Keela
   #   - excluded_path: Path to YAML file of excluded items
   #   - baseline_path: Path to baseline YAML file
   #   - required_directory: Directory that must exist for scanning to proceed
+  #   - strategies: Per-strategy configuration (see below)
   #
   # Example:
   #   # keela.yml
@@ -29,6 +30,15 @@ module Keela
   #     - rb
   #     - haml
   #     - erb
+  #   strategies:
+  #     methods:
+  #       definition_paths:
+  #         - app/helpers
+  #         - app/models
+  #         - lib/
+  #     scopes:
+  #       definition_paths:
+  #         - app/models
   #
   module ConfigFile
     CONFIG_FILENAMES = %w[.keela/config.yml keela.yml .keela.yml].freeze
@@ -74,6 +84,15 @@ module Keela
           value = config[key]
           configuration.public_send("#{key}=", value)
         end
+
+        apply_strategy_options(config["strategies"]) if config.key?("strategies")
+      end
+
+      def apply_strategy_options(strategies)
+        return unless strategies.is_a?(Hash)
+
+        configuration = Keela.configuration
+        configuration.strategy_options = strategies
       end
     end
   end

--- a/lib/keela/configuration.rb
+++ b/lib/keela/configuration.rb
@@ -32,6 +32,12 @@ module Keela
     # Whether to show source location (file:line) in reports
     attr_accessor :source_location
 
+    # Per-strategy configuration options
+    # Hash of strategy_name => { option => value }
+    # Supported options:
+    #   - definition_file_pattern: Regex pattern string for files containing definitions
+    attr_accessor :strategy_options
+
     def initialize
       @extensions = %w[rb haml erb].freeze
       @directory_patterns = %w[
@@ -47,6 +53,12 @@ module Keela
       @include_patterns = []
       @verbose = false
       @source_location = false
+      @strategy_options = {}
+    end
+
+    # Get options for a specific strategy
+    def options_for(strategy_name)
+      strategy_options[strategy_name.to_s] || {}
     end
   end
 end

--- a/lib/keela/strategies/attributes.rb
+++ b/lib/keela/strategies/attributes.rb
@@ -7,7 +7,7 @@ module Keela
         "attributes"
       end
 
-      def definition_file_pattern
+      def default_definition_file_pattern
         # Match app/ and lib/ directories, but exclude spec/ and test/
         %r{(?:^|/)(?:ee/)?(?:app|lib)/}
       end

--- a/lib/keela/strategies/constants.rb
+++ b/lib/keela/strategies/constants.rb
@@ -7,7 +7,7 @@ module Keela
         "constants"
       end
 
-      def definition_file_pattern
+      def default_definition_file_pattern
         # Match app/ and lib/ directories, but exclude spec/ and test/
         %r{(?:^|/)(?:ee/)?(?:app|lib)/}
       end

--- a/lib/keela/strategies/delegations.rb
+++ b/lib/keela/strategies/delegations.rb
@@ -7,7 +7,7 @@ module Keela
         "delegations"
       end
 
-      def definition_file_pattern
+      def default_definition_file_pattern
         # Match app/models/ directories (including concerns), but exclude spec/test
         %r{(?:^|/)(?:ee/)?app/models/}
       end

--- a/lib/keela/strategies/i18n_keys.rb
+++ b/lib/keela/strategies/i18n_keys.rb
@@ -22,7 +22,7 @@ module Keela
         "i18n_keys"
       end
 
-      def definition_file_pattern
+      def default_definition_file_pattern
         # Match locale YAML files
         %r{config/locales/.*\.ya?ml$}
       end

--- a/lib/keela/strategies/methods.rb
+++ b/lib/keela/strategies/methods.rb
@@ -7,7 +7,7 @@ module Keela
         "methods"
       end
 
-      def definition_file_pattern
+      def default_definition_file_pattern
         %r{app/helpers|app/models}
       end
 

--- a/lib/keela/strategies/scopes.rb
+++ b/lib/keela/strategies/scopes.rb
@@ -7,7 +7,7 @@ module Keela
         "scopes"
       end
 
-      def definition_file_pattern
+      def default_definition_file_pattern
         %r{app/models}
       end
 

--- a/lib/keela/strategy.rb
+++ b/lib/keela/strategy.rb
@@ -14,8 +14,23 @@ module Keela
 
     # Regex pattern to match files that may contain definitions
     # (e.g., /app\/models/ for scopes)
+    #
+    # Can be overridden via configuration:
+    #   strategies:
+    #     methods:
+    #       definition_paths:
+    #         - app/helpers
+    #         - app/models
+    #         - lib/
+    #
     def definition_file_pattern
-      raise NotImplementedError, "#{self.class} must implement #definition_file_pattern"
+      configured_pattern || default_definition_file_pattern
+    end
+
+    # Default pattern when no configuration override is provided.
+    # Subclasses should implement this instead of definition_file_pattern.
+    def default_definition_file_pattern
+      raise NotImplementedError, "#{self.class} must implement #default_definition_file_pattern"
     end
 
     # Extract a definition name from a line of code, or nil if no definition found
@@ -38,6 +53,16 @@ module Keela
     # Returns an array of { name:, file: } hashes, or nil to use default line-by-line parsing.
     def extract_definitions_from_file(_filepath, _lines)
       nil
+    end
+
+    private
+
+    def configured_pattern
+      paths = Keela.configuration.options_for(name)["definition_paths"]
+      return nil unless paths.is_a?(Array) && paths.any?
+
+      escaped = paths.map { |p| Regexp.escape(p.to_s) }
+      Regexp.new(escaped.join("|"))
     end
   end
 end

--- a/test/keela/strategy_configuration_test.rb
+++ b/test/keela/strategy_configuration_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StrategyConfigurationTest < Minitest::Test
+  def setup
+    Keela.reset_configuration!
+  end
+
+  def teardown
+    Keela.reset_configuration!
+  end
+
+  def test_methods_uses_default_pattern_without_config
+    strategy = Keela::Strategies::Methods.new
+    assert_equal %r{app/helpers|app/models}, strategy.definition_file_pattern
+  end
+
+  def test_methods_uses_configured_definition_paths
+    Keela.configuration.strategy_options = {
+      "methods" => {
+        "definition_paths" => ["app/helpers", "app/models", "lib/"]
+      }
+    }
+
+    strategy = Keela::Strategies::Methods.new
+    pattern = strategy.definition_file_pattern
+
+    assert pattern.match?("app/helpers/foo.rb")
+    assert pattern.match?("app/models/user.rb")
+    assert pattern.match?("lib/utils.rb")
+    refute pattern.match?("spec/models/user_spec.rb")
+  end
+
+  def test_scopes_uses_configured_definition_paths
+    Keela.configuration.strategy_options = {
+      "scopes" => {
+        "definition_paths" => ["app/models", "ee/app/models"]
+      }
+    }
+
+    strategy = Keela::Strategies::Scopes.new
+    pattern = strategy.definition_file_pattern
+
+    assert pattern.match?("app/models/user.rb")
+    assert pattern.match?("ee/app/models/license.rb")
+    refute pattern.match?("lib/scopes.rb")
+  end
+
+  def test_empty_definition_paths_falls_back_to_default
+    Keela.configuration.strategy_options = {
+      "methods" => {
+        "definition_paths" => []
+      }
+    }
+
+    strategy = Keela::Strategies::Methods.new
+    assert_equal %r{app/helpers|app/models}, strategy.definition_file_pattern
+  end
+
+  def test_missing_strategy_config_uses_default
+    Keela.configuration.strategy_options = {
+      "scopes" => {
+        "definition_paths" => ["custom/path"]
+      }
+    }
+
+    # Methods strategy has no config, should use default
+    strategy = Keela::Strategies::Methods.new
+    assert_equal %r{app/helpers|app/models}, strategy.definition_file_pattern
+  end
+
+  def test_options_for_returns_empty_hash_for_unknown_strategy
+    assert_equal({}, Keela.configuration.options_for("unknown"))
+  end
+
+  def test_options_for_returns_strategy_options
+    Keela.configuration.strategy_options = {
+      "methods" => { "definition_paths" => ["lib/"] }
+    }
+
+    assert_equal({ "definition_paths" => ["lib/"] }, Keela.configuration.options_for("methods"))
+  end
+
+  def test_definition_paths_escapes_special_regex_characters
+    Keela.configuration.strategy_options = {
+      "methods" => {
+        "definition_paths" => ["app/models (legacy)", "lib/v2.0"]
+      }
+    }
+
+    strategy = Keela::Strategies::Methods.new
+    pattern = strategy.definition_file_pattern
+
+    assert pattern.match?("app/models (legacy)/user.rb")
+    assert pattern.match?("lib/v2.0/utils.rb")
+    # Without escaping, "." would match any character
+    refute pattern.match?("lib/v2X0/utils.rb")
+  end
+end


### PR DESCRIPTION
## Summary

Allows customizing where each strategy looks for definitions via the config file. This is useful for projects with code in non-standard locations (like `lib/` or enterprise edition directories) that should be checked for unused definitions.

## Usage

```yaml
# keela.yml
strategies:
  methods:
    definition_paths:
      - app/helpers
      - app/models
      - lib/
  scopes:
    definition_paths:
      - app/models
      - ee/app/models
```

## Implementation

- Add `strategy_options` hash to Configuration
- Add `options_for(strategy_name)` helper method  
- Update Strategy base class to check for configured `definition_paths`
- Rename `definition_file_pattern` to `default_definition_file_pattern` in all strategy subclasses
- Update ConfigFile to parse `strategies` section
- Paths are escaped for regex special characters (e.g., parentheses, dots)

## Testing

- 8 new tests covering configuration, pattern matching, escaping, and fallback behavior

Closes #46