### PR TITLE
Fix class method (def self.foo) usage detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Multi-method delegate declarations now detect all methods, not just the first ([#51](https://github.com/kerrizor/keela/pull/51))
+- Class methods (`def self.foo`) are now correctly detected as unused ([#60](https://github.com/kerrizor/keela/pull/60))
 
 ## [0.3.0] - 2026-08-05
 

--- a/lib/keela/strategies/methods.rb
+++ b/lib/keela/strategies/methods.rb
@@ -18,12 +18,15 @@ module Keela
       end
 
       def usage_regex(name)
+        method_name = Regexp.quote(name.sub(/^self\./, ""))
+
         if name.end_with?("=")
           # Setter method: match assignment usage
-          /(?<!def )#{Regexp.quote(name.sub(/^self\./, "").chomp("="))}\W=*/
+          /(?<!def |def self\.)#{method_name.chomp("=")}\W=*/
         else
           # Regular method: match calls
-          /(?<!def )#{Regexp.quote(name.sub(/^self\./, ""))}\W/
+          # Exclude both "def foo" and "def self.foo" definitions
+          /(?<!def |def self\.)#{method_name}\W/
         end
       end
 

--- a/test/keela/strategies/methods_test.rb
+++ b/test/keela/strategies/methods_test.rb
@@ -99,3 +99,39 @@ class MethodsStrategyTest < Minitest::Test
     assert_match regex, "Model.create("
   end
 end
+
+class MethodsSelfMethodTest < Minitest::Test
+  def setup
+    @strategy = Keela::Strategies::Methods.new
+  end
+
+  def test_extract_definition_captures_self_methods
+    assert_equal "self.class_method", @strategy.extract_definition("def self.class_method")
+    assert_equal "self.class_method", @strategy.extract_definition("  def self.class_method(arg)")
+  end
+
+  def test_usage_regex_excludes_self_method_definitions
+    regex = @strategy.usage_regex("self.class_method")
+
+    # Should NOT match definitions
+    refute regex.match?("def self.class_method")
+    refute regex.match?("  def self.class_method(arg)")
+
+    # Should match actual usage
+    assert regex.match?("User.class_method()")
+    assert regex.match?("self.class_method()")
+    assert regex.match?("result = class_method()")
+  end
+
+  def test_usage_regex_excludes_regular_method_definitions
+    regex = @strategy.usage_regex("instance_method")
+
+    # Should NOT match definitions
+    refute regex.match?("def instance_method")
+    refute regex.match?("  def instance_method(arg)")
+
+    # Should match actual usage
+    assert regex.match?("obj.instance_method()")
+    assert regex.match?("instance_method()")
+  end
+end


### PR DESCRIPTION
## Problem

Class methods defined with `def self.method_name` were incorrectly being marked as "used" because the usage regex only excluded `def ` before the method name, not `def self.`.

**Example:**
- `def self.foo` extracts `self.foo` as the definition name
- The usage regex becomes `(?<!def )foo\W` (after stripping `self.`)
- This matches the definition line itself because `self.` (not `def `) precedes `foo`

## Fix

Update the negative lookbehind to exclude both patterns:
```ruby
(?<!def |def self\.)
```

This correctly excludes both:
- Instance method definitions: `def foo`
- Class method definitions: `def self.foo`

## Testing

Added 3 new tests covering:
- Extraction of `self.method_name` definitions
- Usage regex excluding `def self.foo` definitions
- Usage regex still matching actual class method calls