### PR TITLE
Fix constants usage detection for hash rockets and rescue splats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Constants used as hash keys (`CONST => value`) or in rescue splats (`rescue *ERRORS => e`) are now correctly detected as used ([#63](https://github.com/kerrizor/keela/pull/63))
+
 ## [0.4.0] - 2026-08-14
 
 ### Added

--- a/lib/keela/strategies/constants.rb
+++ b/lib/keela/strategies/constants.rb
@@ -41,8 +41,12 @@ module Keela
         # uppercase letters/digits/underscores (partial match)
         # Uses negative lookahead to avoid:
         #   - partial matches (followed by uppercase letters/digits/underscores)
-        #   - definitions (followed by optional whitespace then =, but not ==)
-        /(?<![A-Z0-9_])#{Regexp.quote(name)}(?![A-Z0-9_])(?!\s*=(?!=))/
+        #   - definitions (followed by optional whitespace then =, but not == or =>)
+        #
+        # The pattern (?!\s*=(?![=>])) means:
+        #   - Don't match if followed by optional whitespace, then =
+        #   - UNLESS that = is followed by = (comparison) or > (hash rocket)
+        /(?<![A-Z0-9_])#{Regexp.quote(name)}(?![A-Z0-9_])(?!\s*=(?![=>]))/
       end
 
       def skip_comments?

--- a/test/keela/strategies/constants_test.rb
+++ b/test/keela/strategies/constants_test.rb
@@ -164,4 +164,26 @@ class ConstantsStrategyTest < Minitest::Test
     regex = @strategy.usage_regex("FOO")
     refute_match regex, "FOO = 'bar'"
   end
+
+  # Issue #61: Rescue splat usage
+  def test_usage_regex_matches_rescue_splat
+    regex = @strategy.usage_regex("TRANSIENT_ERRORS")
+    assert_match regex, "rescue *TRANSIENT_ERRORS => e"
+  end
+
+  # Issue #62: Hash key usage (hash rocket)
+  def test_usage_regex_matches_hash_key_with_rocket
+    regex = @strategy.usage_regex("ENTERED")
+    assert_match regex, "ENTERED => 'value'"
+  end
+
+  def test_usage_regex_matches_hash_key_in_hash_literal
+    regex = @strategy.usage_regex("STATUS")
+    assert_match regex, "{ STATUS => 'active' }"
+  end
+
+  def test_usage_regex_matches_namespaced_constant_as_hash_key
+    regex = @strategy.usage_regex("D")
+    assert_match regex, "B::C::D => 42"
+  end
 end


### PR DESCRIPTION
## Summary

The `usage_regex` was incorrectly excluding constants followed by `=>` (hash rocket) because the negative lookahead `(?!=)` only checked for `==` but not `=>`.

This caused false positives (constants reported as unused) for:

- **Hash keys:** `{ CONSTANT => value }`
- **Rescue splats:** `rescue *ERRORS => e`

## Fix

Change `(?!=)` to `(?![=>])` to allow both `==` and `=>` as valid usages.

## Tests

Added 4 new test cases covering:
- `test_usage_regex_matches_rescue_splat`
- `test_usage_regex_matches_hash_key_with_rocket`
- `test_usage_regex_matches_hash_key_in_hash_literal`
- `test_usage_regex_matches_namespaced_constant_as_hash_key`

Fixes #61
Fixes #62

Thanks @zenspider for the detailed bug reports! 🙏