### PR TITLE
Support pluralization siblings in I18n keys strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Constants used as hash keys (`CONST => value`) or in rescue splats (`rescue *ERRORS => e`) are now correctly detected as used ([#63](https://github.com/kerrizor/keela/pull/63))
 - Methods referenced as literal symbols (`:method_name`) are now detected as used, including Rails callbacks, `send(:method)`, `validate :method`, etc. ([#64](https://github.com/kerrizor/keela/issues/64))
+- I18n pluralization keys (`one`, `other`, `zero`, etc.) are now detected as used when the parent key is called with `t('key', count: n)` ([#69](https://github.com/kerrizor/keela/pull/69))
 
 ## [0.4.0] - 2026-08-14
 

--- a/lib/keela/strategies/i18n_keys.rb
+++ b/lib/keela/strategies/i18n_keys.rb
@@ -15,9 +15,13 @@ module Keela
     #   - t(:key)
     #   - .human_attribute_name(:attr)
     #
+    # Pluralization keys (zero, one, two, few, many, other) are grouped:
+    # if t("items.count", count: n) is called, all siblings are considered used.
+    #
     # Note: Lazy lookup (t('.title') in views) is not yet supported.
     #
     class I18nKeys < Strategy
+      PLURAL_SUFFIXES = %w[zero one two few many other].freeze
       def name
         "i18n_keys"
       end
@@ -32,10 +36,19 @@ module Keela
         return [] unless File.exist?(filepath)
 
         content = YAML.load_file(filepath, permitted_classes: [Symbol]) || {}
-        flatten_keys(content).map do |key|
+        keys = flatten_keys(content).map do |key|
           # Remove the locale prefix (e.g., "en.users.show" -> "users.show")
-          key_without_locale = key.sub(/^[a-z]{2}(-[A-Z]{2})?\./, "")
-          { name: key_without_locale, file: filepath }
+          key.sub(/^[a-z]{2}(-[A-Z]{2})?\./, "")
+        end
+
+        # For pluralization keys, also add the parent key so that
+        # t("items.count", count: n) marks all siblings as used
+        parent_keys = keys.filter_map do |key|
+          parent_key_for_pluralization(key)
+        end.uniq
+
+        (keys + parent_keys).uniq.map do |key|
+          { name: key, file: filepath }
         end
       rescue Psych::SyntaxError => e
         warn "Warning: Could not parse #{filepath}: #{e.message}"
@@ -55,12 +68,20 @@ module Keela
         #   t('users.show.title')
         #   t(:users_show_title) - symbol form (underscored)
         #
-        # Also match partial keys for lazy lookup support:
-        #   t(".title") in a view could match "users.show.title"
+        # For pluralization keys, also match the parent key:
+        #   t("items.count", count: n) should match items.count.one, items.count.other, etc.
         quoted_name = Regexp.quote(name)
 
-        # Build pattern that matches the key in quotes or as a symbol
-        /(?:I18n\.)?t\s*\(\s*["':]+#{quoted_name}["']?\s*[,)]/
+        # Check if this is a pluralization key and build alternate pattern
+        parent_key = parent_key_for_pluralization(name)
+        if parent_key
+          quoted_parent = Regexp.quote(parent_key)
+          # Match either the exact key OR the parent key
+          /(?:I18n\.)?t\s*\(\s*["':]+(?:#{quoted_name}|#{quoted_parent})["']?\s*[,)]/
+        else
+          # Build pattern that matches the key in quotes or as a symbol
+          /(?:I18n\.)?t\s*\(\s*["':]+#{quoted_name}["']?\s*[,)]/
+        end
       end
 
       def skip_comments?
@@ -68,6 +89,18 @@ module Keela
       end
 
       private
+
+      # Returns the parent key if this is a pluralization key, nil otherwise
+      # "items.count.one" -> "items.count"
+      # "users.show.title" -> nil
+      def parent_key_for_pluralization(key)
+        PLURAL_SUFFIXES.each do |suffix|
+          if key.end_with?(".#{suffix}")
+            return key.sub(/\.#{suffix}$/, "")
+          end
+        end
+        nil
+      end
 
       # Flatten nested hash to dot-notation keys
       # { "en" => { "users" => { "title" => "..." } } }

--- a/test/keela/strategies/i18n_keys_test.rb
+++ b/test/keela/strategies/i18n_keys_test.rb
@@ -173,6 +173,62 @@ class I18nKeysUsageRegexTest < Minitest::Test
   end
 end
 
+class I18nKeysPluralizationTest < Minitest::Test
+  def setup
+    @strategy = Keela::Strategies::I18nKeys.new
+    @tmpdir = Dir.mktmpdir
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_pluralization_keys_include_parent_key
+    locale_file = File.join(@tmpdir, "en.yml")
+    File.write(locale_file, <<~YAML)
+      en:
+        items:
+          count:
+            zero: "No items"
+            one: "1 item"
+            other: "%{count} items"
+    YAML
+
+    definitions = @strategy.extract_definitions_from_file(locale_file, [])
+    names = definitions.map { |d| d[:name] }
+
+    # Should include both the full keys AND the parent key
+    assert_includes names, "items.count.zero"
+    assert_includes names, "items.count.one"
+    assert_includes names, "items.count.other"
+    assert_includes names, "items.count"
+  end
+
+  def test_usage_regex_matches_parent_key_for_pluralization
+    # When looking for "items.count.one", should also match t("items.count")
+    regex = @strategy.usage_regex("items.count.one")
+    assert_match regex, 't("items.count", count: 5)'
+  end
+
+  def test_non_pluralization_keys_do_not_get_parent
+    locale_file = File.join(@tmpdir, "en.yml")
+    File.write(locale_file, <<~YAML)
+      en:
+        users:
+          show:
+            title: "User Profile"
+    YAML
+
+    definitions = @strategy.extract_definitions_from_file(locale_file, [])
+    names = definitions.map { |d| d[:name] }
+
+    # Should NOT include parent keys for non-pluralization
+    assert_includes names, "users.show.title"
+    refute_includes names, "users.show"
+    refute_includes names, "users"
+  end
+end
+
 class I18nKeysIntegrationTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir
@@ -222,5 +278,62 @@ class I18nKeysIntegrationTest < Minitest::Test
     assert_includes unused_keys, "users.show.unused_key"
     refute_includes unused_keys, "users.show.title"
     refute_includes unused_keys, "common.save"
+  end
+end
+
+class I18nKeysPluralizationIntegrationTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    # Create locale file with pluralization
+    FileUtils.mkdir_p("config/locales")
+    File.write("config/locales/en.yml", <<~YAML)
+      en:
+        items:
+          count:
+            zero: "No items"
+            one: "1 item"
+            other: "%{count} items"
+        unused:
+          count:
+            one: "1 thing"
+            other: "%{count} things"
+    YAML
+
+    # Create Ruby file that uses the parent key
+    FileUtils.mkdir_p("app/views/items")
+    File.write("app/views/items/index.html.erb", <<~ERB)
+      <p><%= t('items.count', count: @items.size) %></p>
+    ERB
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_pluralization_siblings_detected_as_used
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[config/locales/**/*.yml app/**/*.erb]
+    config.extensions = %w[yml erb]
+
+    strategy = Keela::Strategies::I18nKeys.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.run(force_report: true)
+
+    unused_keys = scanner.unused_collection.values.flatten
+
+    # items.count.* should all be detected as used (via parent key)
+    refute_includes unused_keys, "items.count.zero"
+    refute_includes unused_keys, "items.count.one"
+    refute_includes unused_keys, "items.count.other"
+    refute_includes unused_keys, "items.count"
+
+    # unused.count.* should still be reported as unused
+    assert_includes unused_keys, "unused.count.one"
+    assert_includes unused_keys, "unused.count.other"
   end
 end


### PR DESCRIPTION
## Summary

Pluralization keys (`zero`, `one`, `two`, `few`, `many`, `other`) are now grouped. When `t('items.count', count: n)` is called, all sibling keys are detected as used.

## The Problem

Given this locale file:

```yaml
en:
  items:
    count:
      zero: "No items"
      one: "1 item"
      other: "%{count} items"
```

And this usage:

```ruby
<%= t('items.count', count: @items.size) %>
```

**Before:** Keela reported all three as unused (false positives)
**After:** All three are detected as used via the parent key

## Implementation

1. When extracting definitions, also register the parent key for pluralization suffixes
2. When building usage regex for a pluralization key, also match the parent key

## Tests

- Unit tests for pluralization key extraction
- Unit tests for usage regex matching parent key
- Integration test verifying the full flow

Partial fix for #17 (pluralization siblings item)