### PR TITLE
Support I18n lazy lookup in views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Constants used as hash keys (`CONST => value`) or in rescue splats (`rescue *ERRORS => e`) are now correctly detected as used ([#63](https://github.com/kerrizor/keela/pull/63))
 - Methods referenced as literal symbols (`:method_name`) are now detected as used, including Rails callbacks, `send(:method)`, `validate :method`, etc. ([#64](https://github.com/kerrizor/keela/issues/64))
 - I18n pluralization keys (`one`, `other`, `zero`, etc.) are now detected as used when the parent key is called with `t('key', count: n)` ([#69](https://github.com/kerrizor/keela/pull/69))
+- I18n lazy lookup (`t('.title')` in views) now correctly resolves to the full key based on the view path ([#17](https://github.com/kerrizor/keela/issues/17))
 
 ## [0.4.0] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -199,10 +199,12 @@ Run all strategies (default) or target specific ones with `--type`.
 
 The `i18n_keys` strategy is **beta** and may produce false positives. It cannot detect:
 
-- **Lazy lookup** - `t('.title')` in views resolves based on the view path
 - **Dynamic keys** - `t("users.#{action}.title")` with interpolated segments
 - **Model translations** - `User.human_attribute_name(:email)` and `User.model_name.human`
-- **Pluralization siblings** - If `one:` is used, `other:` may appear unused
+
+The following patterns ARE now supported:
+- **Lazy lookup** - `t('.title')` in views resolves based on the view path
+- **Pluralization siblings** - `t('key', count: n)` marks all plural forms as used
 
 Review results carefully and use the exclusion file for known false positives.
 

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -210,9 +210,16 @@ module Keela
     def find_unused(definitions, show_progress: false)
       source_code = source_files.values.flatten.join
 
+      # Get additional used names from strategy-specific detection
+      # (e.g., I18n lazy lookup)
+      additional_used = strategy.additional_used_names(source_files)
+
       progress_label = show_progress ? "Checking #{strategy.name}" : nil
 
       unused = Parallel.flat_map(definitions, progress: progress_label) do |definition|
+        # Check if marked as used by additional detection
+        next [] if additional_used.include?(definition[:name])
+
         regex = strategy.usage_regex(definition[:name])
         regex.match?(source_code) ? [] : definition
       end

--- a/lib/keela/strategies/i18n_keys.rb
+++ b/lib/keela/strategies/i18n_keys.rb
@@ -18,10 +18,13 @@ module Keela
     # Pluralization keys (zero, one, two, few, many, other) are grouped:
     # if t("items.count", count: n) is called, all siblings are considered used.
     #
-    # Note: Lazy lookup (t('.title') in views) is not yet supported.
+    # Lazy lookup is supported: t('.title') in app/views/users/show.html.erb
+    # resolves to 'users.show.title'.
     #
     class I18nKeys < Strategy
       PLURAL_SUFFIXES = %w[zero one two few many other].freeze
+      VIEW_PATH_REGEX = %r{(?:ee/)?app/views/(.+)\.html\.(?:erb|haml|slim)$}.freeze
+      LAZY_LOOKUP_REGEX = /(?:I18n\.)?t\s*\(\s*['"](\.[^'"]+)['"]/
       def name
         "i18n_keys"
       end
@@ -86,6 +89,52 @@ module Keela
 
       def skip_comments?
         true
+      end
+
+      # Convert a view file path to its I18n prefix
+      # "app/views/users/show.html.erb" -> "users.show"
+      # "app/views/users/_form.html.erb" -> "users.form"
+      # "ee/app/views/users/show.html.erb" -> "users.show"
+      def view_path_to_prefix(path)
+        return nil unless path =~ VIEW_PATH_REGEX
+
+        view_path = Regexp.last_match(1)
+
+        # Split into parts and process
+        parts = view_path.split("/")
+
+        # Handle partials: _form -> form
+        parts[-1] = parts[-1].sub(/^_/, "")
+
+        parts.join(".")
+      end
+
+      # Extract lazy lookup keys from view content
+      # Returns array of keys like [".title", ".description"]
+      def extract_lazy_keys(content)
+        content.scan(LAZY_LOOKUP_REGEX).flatten
+      end
+
+      # Build a set of expanded lazy lookup keys from view files
+      # Called by the scanner to detect usage via lazy lookup
+      def additional_used_names(source_files)
+        expanded = Set.new
+
+        source_files.each do |filepath, lines|
+          prefix = view_path_to_prefix(filepath)
+          next unless prefix
+
+          content = lines.join("\n")
+          lazy_keys = extract_lazy_keys(content)
+
+          lazy_keys.each do |lazy_key|
+            # .title -> users.show.title
+            full_key = "#{prefix}#{lazy_key}"
+            expanded << full_key
+          end
+        end
+
+        expanded
       end
 
       private

--- a/lib/keela/strategy.rb
+++ b/lib/keela/strategy.rb
@@ -55,6 +55,14 @@ module Keela
       nil
     end
 
+    # Override this method for strategies that need to detect usage through
+    # patterns that can't be expressed as a simple regex (e.g., I18n lazy lookup).
+    # Returns a Set of definition names that are considered "used".
+    # Called with the source_files hash { filepath => [lines] }.
+    def additional_used_names(_source_files)
+      Set.new
+    end
+
     private
 
     def configured_pattern

--- a/test/keela/strategies/i18n_keys_test.rb
+++ b/test/keela/strategies/i18n_keys_test.rb
@@ -337,3 +337,109 @@ class I18nKeysPluralizationIntegrationTest < Minitest::Test
     assert_includes unused_keys, "unused.count.other"
   end
 end
+
+class I18nKeysLazyLookupTest < Minitest::Test
+  def setup
+    @strategy = Keela::Strategies::I18nKeys.new
+  end
+
+  def test_view_path_to_i18n_prefix
+    assert_equal "users.show", @strategy.view_path_to_prefix("app/views/users/show.html.erb")
+    assert_equal "users.index", @strategy.view_path_to_prefix("app/views/users/index.html.haml")
+    assert_equal "admin.users.show", @strategy.view_path_to_prefix("app/views/admin/users/show.html.erb")
+  end
+
+  def test_view_path_to_i18n_prefix_for_partials
+    # Partials strip the leading underscore
+    assert_equal "users.form", @strategy.view_path_to_prefix("app/views/users/_form.html.erb")
+    assert_equal "shared.header", @strategy.view_path_to_prefix("app/views/shared/_header.html.erb")
+  end
+
+  def test_view_path_to_i18n_prefix_strips_ee
+    assert_equal "users.show", @strategy.view_path_to_prefix("ee/app/views/users/show.html.erb")
+  end
+
+  def test_view_path_to_i18n_prefix_for_layouts
+    assert_equal "layouts.application", @strategy.view_path_to_prefix("app/views/layouts/application.html.erb")
+  end
+
+  def test_extract_lazy_keys_from_content
+    content = <<~ERB
+      <h1><%= t('.title') %></h1>
+      <p><%= t('.description') %></p>
+      <p><%= t("full.key") %></p>
+    ERB
+
+    lazy_keys = @strategy.extract_lazy_keys(content)
+    assert_includes lazy_keys, ".title"
+    assert_includes lazy_keys, ".description"
+    refute_includes lazy_keys, "full.key"
+  end
+
+  def test_extract_lazy_keys_handles_single_quotes
+    content = "<%= t('.title') %>"
+    lazy_keys = @strategy.extract_lazy_keys(content)
+    assert_includes lazy_keys, ".title"
+  end
+end
+
+class I18nKeysLazyLookupIntegrationTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    # Create locale file
+    FileUtils.mkdir_p("config/locales")
+    File.write("config/locales/en.yml", <<~YAML)
+      en:
+        users:
+          show:
+            title: "User Profile"
+            description: "View user details"
+            unused_key: "Never used"
+        admin:
+          users:
+            index:
+              heading: "All Users"
+    YAML
+
+    # Create view files with lazy lookup
+    FileUtils.mkdir_p("app/views/users")
+    File.write("app/views/users/show.html.erb", <<~ERB)
+      <h1><%= t('.title') %></h1>
+      <p><%= t('.description') %></p>
+    ERB
+
+    FileUtils.mkdir_p("app/views/admin/users")
+    File.write("app/views/admin/users/index.html.erb", <<~ERB)
+      <h1><%= t('.heading') %></h1>
+    ERB
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_lazy_lookup_detected_as_used
+    config = Keela::Configuration.new
+    config.directory_patterns = %w[config/locales/**/*.yml app/views/**/*.erb]
+    config.extensions = %w[yml erb]
+
+    strategy = Keela::Strategies::I18nKeys.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.run(force_report: true)
+
+    unused_keys = scanner.unused_collection.values.flatten
+
+    # These should be detected as used via lazy lookup
+    refute_includes unused_keys, "users.show.title"
+    refute_includes unused_keys, "users.show.description"
+    refute_includes unused_keys, "admin.users.index.heading"
+
+    # This should still be unused
+    assert_includes unused_keys, "users.show.unused_key"
+  end
+end


### PR DESCRIPTION
## Summary

Lazy lookup like `t('.title')` in `app/views/users/show.html.erb` now correctly resolves to `users.show.title` and marks the key as used.

## Example

Given:
```yaml
# config/locales/en.yml
en:
  users:
    show:
      title: "User Profile"
```

And:
```erb
# app/views/users/show.html.erb
<h1><%= t('.title') %></h1>
```

**Before:** Keela reported `users.show.title` as unused
**After:** Keela correctly detects it as used via lazy lookup

## Implementation

1. **`view_path_to_prefix()`** - Converts view paths to I18n prefixes:
   - `app/views/users/show.html.erb` → `users.show`
   - `app/views/users/_form.html.erb` → `users.form` (partials)
   - `ee/app/views/users/show.html.erb` → `users.show` (strips ee/)

2. **`extract_lazy_keys()`** - Finds `t('.key')` patterns in view content

3. **`additional_used_names()`** - New hook in Strategy base class for usage detection that can't be expressed as a simple regex

4. **Scanner integration** - Checks the hook before running regex matching

## Tests

- Unit tests for path-to-prefix conversion (including partials, layouts, ee/)
- Unit tests for lazy key extraction
- Integration test verifying the full flow

Partial fix for #17