### PR TITLE
Deduplicate unused entries per file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Unused entries are no longer listed more than once per file in reports and baselines when a single definition is extracted from multiple lines (e.g. the same method delegated twice, or a constant declared and referenced)
+- Unused entries are no longer listed more than once per file in reports and baselines when a single definition is extracted from multiple lines (e.g. the same method delegated twice, or a constant declared and referenced) ([#72](https://github.com/kerrizor/keela/pull/72))
 
 ## [0.4.1] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Unused entries are no longer listed more than once per file in reports and baselines when a single definition is extracted from multiple lines (e.g. the same method delegated twice, or a constant declared and referenced)
+
 ## [0.4.1] - 2026-08-21
 
 ### Fixed

--- a/lib/keela/scanner.rb
+++ b/lib/keela/scanner.rb
@@ -224,8 +224,15 @@ module Keela
         regex.match?(source_code) ? [] : definition
       end
 
+      # A single logical definition can be extracted from multiple lines
+      # (e.g. the same method delegated twice, or a constant declared and
+      # referenced), so guard against listing the same name twice per file.
+      #
       unused.each do |unused_def|
-        @unused_collection[unused_def[:file]] << unused_def[:name]
+        names = @unused_collection[unused_def[:file]]
+        next if names.include?(unused_def[:name])
+
+        names << unused_def[:name]
         if unused_def[:line]
           @source_locations["#{unused_def[:file]}:#{unused_def[:name]}"] = unused_def[:line]
         end

--- a/test/keela/scanner_test.rb
+++ b/test/keela/scanner_test.rb
@@ -814,6 +814,66 @@ class ScannerConfigurationValidationTest < Minitest::Test
   end
 end
 
+class ScannerDeduplicationTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @original_dir = Dir.pwd
+    Dir.chdir(@tmpdir)
+
+    FileUtils.mkdir_p("app/models")
+  end
+
+  def teardown
+    Dir.chdir(@original_dir)
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_does_not_list_the_same_unused_name_twice_per_file
+    # The same method is delegated in two separate statements, producing two
+    # definitions that both resolve to the same unused name. The collection
+    # must list it only once.
+    File.write("app/models/order.rb", <<~RUBY)
+      class Order
+        delegate :duplicated, to: :user
+        delegate :duplicated, to: :account
+      end
+    RUBY
+
+    config = Keela::Configuration.new
+    strategy = Keela::Strategies::Delegations.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.run(force_report: true, silent: true)
+
+    unused = scanner.unused_collection["app/models/order.rb"]
+    assert_equal 1, unused.count("duplicated"),
+      "Expected 'duplicated' to appear exactly once, got: #{unused.inspect}"
+  end
+
+  def test_deduplicates_across_multiple_files_independently
+    File.write("app/models/a.rb", <<~RUBY)
+      class A
+        delegate :shared, to: :user
+        delegate :shared, to: :account
+      end
+    RUBY
+    File.write("app/models/b.rb", <<~RUBY)
+      class B
+        delegate :shared, to: :user
+      end
+    RUBY
+
+    config = Keela::Configuration.new
+    strategy = Keela::Strategies::Delegations.new
+    scanner = Keela::Scanner.new(strategy: strategy, configuration: config)
+
+    scanner.run(force_report: true, silent: true)
+
+    assert_equal ["shared"], scanner.unused_collection["app/models/a.rb"]
+    assert_equal ["shared"], scanner.unused_collection["app/models/b.rb"]
+  end
+end
+
 class ScannerMultiMethodDelegateTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir


### PR DESCRIPTION
## Summary

A single logical definition can be extracted from multiple source lines — for example the same method delegated in two `delegate` statements, or a constant declared and later referenced. Each extraction produced a definition that was appended to the per-file collection without deduplication, so the same name appeared multiple times in reports and baselines.

## Fix

Guard the append in `Scanner#find_unused` so each name is listed at most once per file, preserving the first-seen source location.

## Testing

- Added `ScannerDeduplicationTest` covering:
  - the same unused name is listed exactly once per file
  - deduplication is scoped per-file independently
- Full suite green: 329 runs, 650 assertions, 0 failures

## Changelog

Added an `[Unreleased] > Fixed` entry.