### PR TITLE
Test Ruby 3.3, 3.4, 4.0; drop EOL 3.1/3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3']
+        ruby-version: ['3.3', '3.4', '4.0']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CI now tests against Ruby 3.3, 3.4, and 4.0; dropped end-of-life Ruby 3.1 and 3.2. Minimum required Ruby is now 3.3.0
+
 ### Fixed
 
 - Unused entries are no longer listed more than once per file in reports and baselines when a single definition is extracted from multiple lines (e.g. the same method delegated twice, or a constant declared and referenced) ([#72](https://github.com/kerrizor/keela/pull/72))

--- a/keela.gemspec
+++ b/keela.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/kerrizor/keela"
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 3.1.0"
+  s.required_ruby_version = ">= 3.3.0"
 
   s.files = Dir.glob(%w[
     lib/**/*.rb


### PR DESCRIPTION
## What

- Update CI matrix from `3.1, 3.2, 3.3` to `3.3, 3.4, 4.0`
- Raise gemspec `required_ruby_version` to `>= 3.3.0`
- Add CHANGELOG entry

## Why

Ruby 3.1 (EOL Mar 2025) and 3.2 (EOL Mar 2026) no longer receive security updates. Ruby 4.0 (Dec 2025) and 3.4 are current supported releases and were untested.